### PR TITLE
feat: Allow to see the opt out status

### DIFF
--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -192,6 +192,8 @@ class MatomoTracker {
     _prefs?.setBool(kOptOut, _optout);
   }
 
+  bool getOptOut() => _prefs?.getBool(kOptOut) ?? false;
+
   /// Clear the following data from the SharedPreferences:
   ///
   /// - First visit


### PR DESCRIPTION
It's great to allow to get the value without extracting the key from the source code to show to the end user if they are opt out or not