### PR TITLE
fix: Allow await for async optOut call

### DIFF
--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -187,9 +187,9 @@ class MatomoTracker {
 
   bool? get optOut => _optout;
 
-  void setOptOut({required bool optout}) {
+  Future<void> setOptOut({required bool optout}) async {
     _optout = optout;
-    _prefs?.setBool(kOptOut, _optout);
+    await _prefs?.setBool(kOptOut, _optout);
   }
 
   bool getOptOut() => _prefs?.getBool(kOptOut) ?? false;


### PR DESCRIPTION
Now anyone can await the optOut call if needed. 
For example a Switch wouldn't update if you would directly depend it's value on the provided optOut call