### PR TITLE
fix: Send country only in combination with auth_token

### DIFF
--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -58,6 +58,10 @@ class MatomoTracker {
   final _queue = Queue<MatomoEvent>();
   late Timer _timer;
 
+  String? _tokenAuth;
+
+  String? get getAuthToken => _tokenAuth;
+
   Future<void> initialize({
     required int siteId,
     required String url,
@@ -77,6 +81,7 @@ class MatomoTracker {
         const Uuid().v4().replaceAll('-', '').substring(0, 16);
     visitor = Visitor(id: _visitorId, userId: _visitorId);
 
+    _tokenAuth = tokenAuth;
     _dispatcher = MatomoDispatcher(url, tokenAuth);
 
     // User agent

--- a/lib/src/matomo_event.dart
+++ b/lib/src/matomo_event.dart
@@ -134,7 +134,7 @@ class MatomoEvent {
       'cookie': '1',
       if (ua != null) 'ua': ua,
       'lang': window.locale.toString(),
-      if (country != null) 'country': country,
+      if (country != null && tracker.getAuthToken != null) 'country': country,
 
       if (uid != null) 'uid': uid,
       if (cid != null) 'cid': cid,


### PR DESCRIPTION
Fixes Matomo returning statuscode `400` when sending country without a auth token
Fixes: #8

@TesteurManiak (ping because it's a breaking bug)