### PR TITLE
Feature addition: Visitor's userId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.1]
+
+* Added support for Visitor's userId
+  * Solves [#12](https://github.com/Floating-Dartists/matomo-tracker/issues/13) by allowing a userId coming from a third-party source (eg. Firebase) to be linked to the visitor.
+  * Is accessible through the setVisitorUserId() method of the MatomoTracker instance.
+  * No breaking changes.
+
 ## [1.2.0]
 
 * Fix [#9](https://github.com/Floating-Dartists/matomo-tracker/issues/9) (Contribution from [Marvin Möltgen](https://github.com/M123-dev))

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -35,7 +35,14 @@ class MatomoTracker {
   late final int siteId;
   late final String url;
   late final Session session;
-  late final Visitor visitor;
+
+  Visitor get visitor => _visitor;
+  late Visitor _visitor;
+
+  void setVisitorUserId(String? userId) {
+    _visitor =
+        Visitor(id: _visitor.id, forcedId: _visitor.forcedId, userId: userId);
+  }
 
   /// The user agent is used to detect the operating system and browser used.
   late final String? userAgent;
@@ -79,7 +86,7 @@ class MatomoTracker {
     final _visitorId = visitorId ??
         _prefs?.getString(kVisitorId) ??
         const Uuid().v4().replaceAll('-', '').substring(0, 16);
-    visitor = Visitor(id: _visitorId, userId: _visitorId);
+    _visitor = Visitor(id: _visitorId, userId: _visitorId);
 
     _tokenAuth = tokenAuth;
     _dispatcher = MatomoDispatcher(url, tokenAuth);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: matomo_tracker
 description: A fully cross-platform wrap of the Matomo tracking client for Flutter, using the Matomo API.
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/Floating-Dartists/matomo-tracker
 
 environment:


### PR DESCRIPTION
* Added support for Visitor's userId
  * Solves [#12](https://github.com/Floating-Dartists/matomo-tracker/issues/13) by allowing a userId coming from a third-party source (eg. Firebase) to be linked to the visitor.
  * Is accessible through the setVisitorUserId() method of the MatomoTracker instance.
  * No breaking changes.