### PR TITLE
Feature: Add dimensions tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,27 @@ If you want to offer a way for the user to opt out of analytics, you can use the
 MatomoTracker.instance.setOptOut(optout: true);
 ```
 
+## Using Dimensions
+
+If you want to track Visit or Action dimensions you can either use the `trackDimensions` (if 
+it's a Visit level dimension) or provide data in the optional dimensions param of `trackEvent`
+(if it's an Action level dimension):
+
+```dart
+MatomoTracker.instance.trackDimensions({
+  'dimension1': '0.0.1'
+});
+```
+
+```dart
+MatomoTracker.instance.trackEvent(
+    name: 'eventName',
+    action: 'eventAction',
+    eventValue: 18,
+    dimensions: {'dimension2':'guest-user'}
+);
+```
+
 ## Contributors
 
 <!-- readme: contributors -start -->

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -308,15 +308,25 @@ class MatomoTracker {
     @Deprecated('Please use [eventName] instead') String? name,
     @Deprecated('Please use [eventCategory] instead') String? widgetName,
     int? eventValue,
+    Map<String, String>? dimensions,
   }) {
     return _track(
       MatomoEvent(
+          tracker: this,
+          action: action,
+          eventAction: action,
+          eventName: name ?? eventName,
+          eventCategory: widgetName ?? eventCategory,
+          eventValue: eventValue,
+          dimensions: dimensions),
+    );
+  }
+
+  void trackDimensions(Map<String, String> dimensions) {
+    return _track(
+      MatomoEvent(
         tracker: this,
-        action: action,
-        eventAction: action,
-        eventName: name ?? eventName,
-        eventCategory: widgetName ?? eventCategory,
-        eventValue: eventValue,
+        dimensions: dimensions,
       ),
     );
   }

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -312,13 +312,14 @@ class MatomoTracker {
   }) {
     return _track(
       MatomoEvent(
-          tracker: this,
-          action: action,
-          eventAction: action,
-          eventName: name ?? eventName,
-          eventCategory: widgetName ?? eventCategory,
-          eventValue: eventValue,
-          dimensions: dimensions),
+        tracker: this,
+        action: action,
+        eventAction: action,
+        eventName: name ?? eventName,
+        eventCategory: widgetName ?? eventCategory,
+        eventValue: eventValue,
+        dimensions: dimensions,
+      ),
     );
   }
 

--- a/lib/src/matomo_event.dart
+++ b/lib/src/matomo_event.dart
@@ -53,6 +53,9 @@ class MatomoEvent {
 
   final String? link;
 
+  // The dimensions associated with the event
+  final Map<String, String>? dimensions;
+
   MatomoEvent({
     required this.tracker,
     this.path,
@@ -73,6 +76,7 @@ class MatomoEvent {
     this.searchCategory,
     this.searchCount,
     this.link,
+    this.dimensions,
   })  : _date = DateTime.now().toUtc(),
         assert(
           eventCategory == null || eventCategory.isNotEmpty,
@@ -109,6 +113,7 @@ class MatomoEvent {
     final ecDt = discountAmount;
     final ua = tracker.userAgent;
     final country = window.locale.countryCode;
+    final dims = dimensions ?? {};
 
     return {
       // Required parameters
@@ -167,6 +172,6 @@ class MatomoEvent {
 
       // Other parameters (require authentication via `token_auth`)
       'cdt': _date.toIso8601String(),
-    };
+    }..addAll(dims);
   }
 }


### PR DESCRIPTION
## What

* Adds support for tracking dimensions (Matomo documentation on Custom Dimensions: https://matomo.org/faq/reporting-tools/create-track-and-manage-custom-dimensions/)
* As mentioned in https://github.com/Floating-Dartists/matomo-tracker/issues/16, example use cases would be tracking of App Version or tracking of App Content Language. 

## Implementation considerations

* Basically the dimensions are key value pairs, so in the proposed implementation just adding them to the query params.
* There are two ways to add the dimensions, either when an event is tracked (and dimensions is an optional argument) via the updated `trackEvent`, or via a new function `trackDimensions`

## Documentation

* Info on setting up custom dimensions on Matomo can be found here: https://matomo.org/faq/reporting-tools/create-track-and-manage-custom-dimensions/ and on the dimensions arguments in the API here: https://developer.matomo.org/api-reference/tracking-api
* Updated also the README file with usage examples


