### PR TITLE
Add pause and resume capabilities with lock mechanism to prevent concurrent access

### DIFF
--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -17,7 +17,7 @@ import 'platform_info/platform_info.dart';
 import 'session.dart';
 import 'tracking_order_item.dart';
 import 'visitor.dart';
-import 'package:synchronized/synchronized.dart' as sync;
+import '../utils/lock.dart' as sync;
 
 class MatomoTracker {
   static const kFirstVisit = 'matomo_first_visit';
@@ -88,7 +88,7 @@ class MatomoTracker {
     );
     this.siteId = siteId;
     this.url = url;
-    this._dequeueInterval = dequeueInterval;
+    _dequeueInterval = dequeueInterval;
     _lock = sync.Lock();
     _prefs = await SharedPreferences.getInstance();
 

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -233,6 +233,22 @@ class MatomoTracker {
       _dequeue();
     }
   }
+  
+  // Pause tracker
+  void pause() {
+    if(initialized){
+      _timer.cancel();
+      _dequeue();
+    }
+  }
+  
+  void resume(){
+    if (initialized && !_timer?.isActive==true) {
+      _timer = Timer.periodic(Duration(seconds: dequeueInterval), (timer) {
+      _dequeue();
+    });
+    }
+  }
 
   /// This will register an event with [trackScreenWithName] by using the
   /// `context.widget.toStringShort()` value.

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -9,6 +9,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 
+import '../utils/lock.dart' as sync;
 import '../utils/random_alpha_numeric.dart';
 import 'logger.dart';
 import 'matomo_dispatcher.dart';
@@ -17,7 +18,6 @@ import 'platform_info/platform_info.dart';
 import 'session.dart';
 import 'tracking_order_item.dart';
 import 'visitor.dart';
-import '../utils/lock.dart' as sync;
 
 class MatomoTracker {
   static const kFirstVisit = 'matomo_first_visit';

--- a/lib/utils/lock.dart
+++ b/lib/utils/lock.dart
@@ -1,0 +1,32 @@
+import 'dart:async';
+
+/// Simple lock implementation to prevent concurrent access to asynchronous
+/// code.
+///
+/// Based on tekartik's [basic_lock.dart](https://github.com/tekartik/synchronized.dart/blob/master/synchronized/lib/src/basic_lock.dart)
+class Lock {
+  Future<dynamic>? last;
+
+  bool get locked => last != null;
+
+  Future<T> synchronized<T>(
+    FutureOr<T> Function() func,
+  ) async {
+    final prev = last;
+    final completer = Completer.sync();
+    last = completer.future;
+    try {
+      if (prev != null) {
+        await prev;
+      }
+
+      final result = func();
+      return result;
+    } finally {
+      if (identical(last, completer.future)) {
+        last = null;
+      }
+      completer.complete();
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   package_info_plus: ^3.0.1
   shared_preferences: ^2.0.15
   uuid: ^3.0.6
-  synchronized: ^3.0.0+3
 
 dev_dependencies:
   flutter_lints: ^2.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   package_info_plus: ^3.0.1
   shared_preferences: ^2.0.15
   uuid: ^3.0.6
+  synchronized: ^3.0.0+3
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
Hello team,

Thank you to develop this tracker for Matomo. 👍 
I noticed that the timer keeps running when the app is in the background.
So I added development to handle pause and resume timer if needed and I added a lock mechanism to prevent the queue from being processed concurrently if the processing is longer than the timer periodicity.

Example of use 


```
void didChangeAppLifecycleState(AppLifecycleState state) {
    if (state == AppLifecycleState.paused) {
      MatomoTracker.instance.pause(); 
    } else if (state == AppLifecycleState.resumed){
      MatomoTracker.instance.resume();
    }
  }
```

I let you see if this development is interesting for the project.

Sébastien
