### PR TITLE
Add support for Matomo Bulk Tracking REST API

### DIFF
--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -275,6 +275,9 @@ class MatomoTracker {
     String? path,
     Map<String, String>? dimensions,
   }) {
+    if (currentScreenId != null) {
+      this.currentScreenId = currentScreenId;
+    }
     final widgetName = context.widget.toStringShort();
     trackScreenWithName(
       widgetName: widgetName,

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -453,11 +453,10 @@ class MatomoTracker {
     log.finest('Processing queue ${_queue.length}');
     if(!_lock.locked){
       _lock.synchronized(() {
-        while (_queue.isNotEmpty) {
-          final event = _queue.removeFirst();
-          if (!_optout) {
-            _dispatcher.send(event);
-          }
+        final events = List<MatomoEvent>.from(_queue);
+        _queue.clear();
+        if (!_optout) {
+          _dispatcher.sendBatch(events);
         }
       });
     }

--- a/lib/src/matomo_event.dart
+++ b/lib/src/matomo_event.dart
@@ -27,6 +27,10 @@ class MatomoEvent {
   /// The event value.
   final num? eventValue;
 
+  /// 6 character unique ID that identifies which actions were performed on a
+  /// specific page view.
+  final String? screenId;
+
   final int? goalId;
   final String? orderId;
   final List<TrackingOrderItem>? trackingOrderItems;
@@ -64,6 +68,7 @@ class MatomoEvent {
     this.eventAction,
     this.eventName,
     this.eventValue,
+    String? screenId,
     this.goalId,
     this.orderId,
     this.trackingOrderItems,
@@ -78,6 +83,11 @@ class MatomoEvent {
     this.link,
     this.dimensions,
   })  : _date = DateTime.now().toUtc(),
+        screenId = screenId ?? tracker.currentScreenId,
+        assert(
+          screenId == null || screenId.length == 6,
+          'screenId has to be six characters long',
+        ),
         assert(
           eventCategory == null || eventCategory.isNotEmpty,
           'eventCategory must not be empty',
@@ -95,7 +105,7 @@ class MatomoEvent {
     final id = tracker.visitor.id;
     final cid = tracker.visitor.forcedId;
     final uid = tracker.visitor.userId;
-    final pvId = tracker.currentScreenId;
+    final pvId = screenId;
     final actionName = action;
     final url =
         path != null ? '${tracker.contentBase}/$path' : tracker.contentBase;


### PR DESCRIPTION
These changes add a `sendBatch(List<MatomoEvent>)` function to the `MatomoDispatcher`, which sends the entire queue using only one HTTP POST request, as specified in the [Matomo API documentation](https://developer.matomo.org/api-reference/tracking-api#bulk-tracking).

Additionally I have fixed the error mentioned in #33, by saving the `currentScreenId` in the `MatomoEvent` itself. Previously only the latests screen id was used in all batched requests, which resulted in Matomo assuming that all batched tracking events were performed on the same screen.