### PR TITLE
Remove internal visitorId assertion

### DIFF
--- a/lib/src/visitor.dart
+++ b/lib/src/visitor.dart
@@ -20,8 +20,7 @@ class Visitor {
   final String? userId;
 
   Visitor({this.id, this.forcedId, this.userId})
-      : assert(id == null || id.length == 16, 'id must be 16 characters'),
-        assert(userId == null || userId.isNotEmpty, 'userId must not be empty'),
+      : assert(userId == null || userId.isNotEmpty, 'userId must not be empty'),
         assert(
           forcedId == null || forcedId.length == 16,
           'forcedId must be 16 characters',


### PR DESCRIPTION
This permits migration from the upstream package.

We still check the user-supplied visitorId format but allow Matomo server to deal with the incorrect format from the old package (substring of sha1 digest).

The existing (UUID) user ID is also still supplied to Matomo because we default to using the visitorId for that field.