### PR TITLE
Avoid applying potentially invalid HTTP headers

### DIFF
--- a/lib/src/matomo_dispatcher.dart
+++ b/lib/src/matomo_dispatcher.dart
@@ -15,9 +15,8 @@ class MatomoDispatcher {
         httpClient = httpClient ?? http.Client();
 
   void send(MatomoEvent event) {
-    final userAgent = event.tracker.userAgent;
     final headers = <String, String>{
-      if (!kIsWeb && userAgent != null) 'User-Agent': userAgent,
+      if (!kIsWeb) 'User-Agent': 'Dart Matomo Tracker',
     };
 
     final queryParameters = Map<String, String>.from(baseUri.queryParameters)


### PR DESCRIPTION
We hardcode the HTTP header User-Agent or use the one supplied by the web browser.

The constructed user agent information is still supplied to Matomo via the ua parameter so device-detector should not output any different result due to this change.

See #39 