### PR TITLE
Feat/#53 cookieless mode

### DIFF
--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -16,3 +16,11 @@ class UninitializedMatomoInstanceException extends MatomoException {
               'MatomoTracker has not been initialized properly, call the method initialize() first.',
         );
 }
+
+class AlreadyInitializedMatomoInstanceException extends MatomoException {
+  const AlreadyInitializedMatomoInstanceException()
+      : super(
+          message: 'MatomoTracker has already been initialized. '
+              'You can check the initialize property to see if it has been initialized.',
+        );
+}

--- a/lib/src/local_storage/cookieless_storage.dart
+++ b/lib/src/local_storage/cookieless_storage.dart
@@ -15,9 +15,7 @@ class CookielessStorage implements LocalStorage {
   Future<void> clear() => storage.clear();
 
   @override
-  Future<DateTime?> getFirstVisit() {
-    return Future.value();
-  }
+  Future<DateTime?> getFirstVisit() => Future.value();
 
   @override
   Future<bool> getOptOut() => storage.getOptOut();
@@ -26,14 +24,10 @@ class CookielessStorage implements LocalStorage {
   Future<int> getVisitCount() => storage.getVisitCount();
 
   @override
-  Future<String?> getVisitorId() {
-    return Future.value();
-  }
+  Future<String?> getVisitorId() => Future.value();
 
   @override
-  Future<void> setFirstVisit(DateTime firstVisit) {
-    return Future.value();
-  }
+  Future<void> setFirstVisit(DateTime _) => Future.value();
 
   @override
   Future<void> setOptOut({required bool optOut}) {
@@ -46,7 +40,5 @@ class CookielessStorage implements LocalStorage {
   }
 
   @override
-  Future<void> setVisitorId(String visitorId) {
-    return Future.value();
-  }
+  Future<void> setVisitorId(String _) => Future.value();
 }

--- a/lib/src/local_storage/cookieless_storage.dart
+++ b/lib/src/local_storage/cookieless_storage.dart
@@ -1,0 +1,52 @@
+import 'package:matomo_tracker/src/local_storage/local_storage.dart';
+
+/// A [LocalStorage] implementation that does not store any specific user data.
+///
+/// It implements stub methods that return empty values for properties
+/// first_visit and visitor_id.
+///
+/// Other methods are delegated to the [storage] parameter.
+class CookielessStorage implements LocalStorage {
+  CookielessStorage({required this.storage});
+
+  final LocalStorage storage;
+
+  @override
+  Future<void> clear() => storage.clear();
+
+  @override
+  Future<DateTime?> getFirstVisit() {
+    return Future.value();
+  }
+
+  @override
+  Future<bool> getOptOut() => storage.getOptOut();
+
+  @override
+  Future<int> getVisitCount() => storage.getVisitCount();
+
+  @override
+  Future<String?> getVisitorId() {
+    return Future.value();
+  }
+
+  @override
+  Future<void> setFirstVisit(DateTime firstVisit) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> setOptOut({required bool optOut}) {
+    return storage.setOptOut(optOut: optOut);
+  }
+
+  @override
+  Future<void> setVisitCount(int visitCount) {
+    return storage.setVisitCount(visitCount);
+  }
+
+  @override
+  Future<void> setVisitorId(String visitorId) {
+    return Future.value();
+  }
+}

--- a/lib/src/local_storage/local_storage.dart
+++ b/lib/src/local_storage/local_storage.dart
@@ -7,5 +7,13 @@ abstract class LocalStorage {
   Future<void> setVisitCount(int visitCount);
   Future<bool> getOptOut();
   Future<void> setOptOut({required bool optOut});
+
+  /// {@template local_storage.clear}
+  /// Clear the following data from the local storage:
+  ///
+  /// - First visit
+  /// - Number of visits
+  /// - Visitor ID
+  /// {@endtemplate}
   Future<void> clear();
 }

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -523,12 +523,14 @@ class MatomoTracker {
   }
 
   Future<void> _saveVisitorId(String? visitorId) async {
-    if (_cookieless || visitorId == null) return;
+    if (visitorId == null) return;
 
     await _localStorage.setVisitorId(visitorId);
   }
 
   Future<String?> _getVisitorId() async {
+    /// The check is needed here as we don't want to create a new visitor id
+    /// with Uuid if the user has opted out.
     if (_cookieless) return null;
 
     final localId = await _localStorage.getVisitorId();


### PR DESCRIPTION
Fix #53 

The main idea here is to use an instance of `CookielessStorage` which will wrap the underlying `LocalStorage` implementation to fake the calls to `getFirstVisit`, `setFirstVisit`, `getVisitorId` and `setVisitorId`.