### PR TITLE
Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ await MatomoTracker.instance.initialize(
     visitorId: '2589631479517535',
 );
 ```
+Note that this Visitor ID should not be confused with the User ID which is explained below!
 
 To track views simply add `TraceableClientMixin` on your `State`:
 
@@ -79,6 +80,9 @@ class _MyHomePageState extends State<MyHomePage> with TraceableClientMixin {
   String get traceName => 'Created HomePage'; // optional
 
   @override
+  String get path => '/home'; // optional
+
+  @override
   String get traceTitle => widget.title;
 }
 ```
@@ -95,6 +99,7 @@ class MyHomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return TraceableWidget(
       traceName: 'Created HomePage', // optional
+      path: '/home', // optional
       traceTitle: title,
       child: Scaffold(
         appBar: AppBar(
@@ -170,6 +175,8 @@ MatomoTracker.instance.trackScreenWithName(
       dimensions: {'dimension1': '0.0.1'}
     );
 ```
+
+The naming of the dimensions is important and explained in more detail in the documentation of [`trackDimensions`](https://pub.dev/documentation/matomo_tracker/latest/matomo_tracker/MatomoTracker/trackDimensions.html).
 
 ## Cookieless Tracking
 

--- a/lib/src/traceable_widget_mixin.dart
+++ b/lib/src/traceable_widget_mixin.dart
@@ -5,25 +5,34 @@ import 'package:matomo_tracker/matomo_tracker.dart';
 @optionalTypeArgs
 mixin TraceableClientMixin<T extends StatefulWidget> on State<T> {
   /// {@template traceableClientMixin.traceName}
-  /// Equivalent to an event action. (e.g. `'Created HomePage'`)
+  /// Equivalent to an event action. (e.g. `'Created HomePage'`).
+  ///
+  /// This corresponds with `action_name`.
   /// {@endtemplate}
   @protected
   String get traceName => 'Created widget ${widget.toStringShort()}';
 
   /// {@template traceableClientMixin.traceTitle}
-  /// Equivalent to an event name. (e.g. `'HomePage'`)
+  /// Equivalent to an event name. (e.g. `'HomePage'`).
+  ///
+  /// This corresponds with `e_n`.
   /// {@endtemplate}
   @protected
   String get traceTitle;
 
   /// {@template traceableClientMixin.widgetId}
   /// A 6 character unique ID. If `null`, a random id will be generated.
+  ///
+  /// This corresponds with `pv_id`.
   /// {@endtemplate}
   @protected
   String? widgetId;
 
   /// {@template traceableClientMixin.path}
-  /// Path to the widget. (e.g. `'/home'`)
+  /// Path to the widget. (e.g. `'/home'`).
+  ///
+  /// This will be combined with [MatomoTracker.contentBase]. The combination
+  /// corresponds with `url`.
   /// {@endtemplate}
   @protected
   String? path;

--- a/lib/src/visitor.dart
+++ b/lib/src/visitor.dart
@@ -27,5 +27,7 @@ class Visitor {
 
   /// User ID is any non-empty unique string identifying the user (such as an
   /// email address or an username).
+  /// 
+  /// Corresponds with the `uid` parameter.
   final String? userId;
 }


### PR DESCRIPTION
From my understanding, this package uses the [Tracking HTTP API](https://developer.matomo.org/api-reference/tracking-api).

On some methods it was not clear to me what the parameters actually mean so I got through the code and tried to find out to which parameter of the dart API matches what parameter of the tracking API and just add these correspondences to the documentation.

I also fixed a mistake where it currently states that
https://github.com/Floating-Dartists/matomo-tracker/blob/2dbf25209c995762daf6461cbcfa5ca0952798ef/lib/src/matomo.dart#L111
where it should be `visitorId` instead.

Also, I wonder why `int` and not `num` is used for `eventValue` in `trackEvent`
https://github.com/Floating-Dartists/matomo-tracker/blob/2dbf25209c995762daf6461cbcfa5ca0952798ef/lib/src/matomo.dart#L395
because the tracking API states that it can be an int or float, but this should maybe be discussed in a separate issue.

I tried to not write code and just write documentation because I'm still not able to write tests (see #59...) but I could not resist to add some checks to the `trackDimensions` method 😅.

Moreover I think the concept of `_id` (which is `visitorId`), `cid` (which is `forcedId`) and `uid` (which is `userId`) is a bit confusing... I'd love to add some more explanations on that, but haven't understood it fully yet myself... For example, why can `visitorId` be set in initialization but not `userId`? What is the puropse of `forceId` if the user can not set it? Or can he actually set it somehow and I'm missing something?

Also I've not updated `CHANGELOG.md` and the `pubspec.yaml` yet because I belive there might be some discussions about these changes 😄.