### PR TITLE
Remove send from dispatcher

### DIFF
--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -117,7 +117,7 @@ class MatomoTracker {
 
   String? get getAuthToken => _tokenAuth;
 
-  int _dequeueInterval = 10;
+  late final int _dequeueInterval;
 
   /// Initialize the tracker.
   ///

--- a/lib/src/matomo_dispatcher.dart
+++ b/lib/src/matomo_dispatcher.dart
@@ -19,23 +19,6 @@ class MatomoDispatcher {
   static const tokenAuthUriKey = 'token_auth';
   static const userAgentHeaderKeys = 'User-Agent';
 
-  Future<void> send(MatomoEvent event) async {
-    final headers = <String, String>{
-      if (!kIsWeb) 'User-Agent': 'Dart Matomo Tracker',
-      ...event.tracker.customHeaders,
-    };
-
-    final uri = buildUriForEvent(event);
-    event.tracker.log.fine(' -> $uri');
-    try {
-      final response = await httpClient.post(uri, headers: headers);
-      final statusCode = response.statusCode;
-      event.tracker.log.fine(' <- $statusCode');
-    } catch (e) {
-      event.tracker.log.severe(message: ' <- $e', error: e);
-    }
-  }
-
   /// Sends a batch of events to the Matomo server.
   ///
   /// The events are sent in a single request.

--- a/test/src/matomo_dispatcher_test.dart
+++ b/test/src/matomo_dispatcher_test.dart
@@ -19,67 +19,6 @@ void main() {
     when(() => mockMatomoTracker.customHeaders).thenReturn({});
   });
 
-  group('send', () {
-    test('it should be able to send MatomoEvent', () async {
-      when(() => mockHttpClient.post(any(), headers: any(named: 'headers')))
-          .thenAnswer((_) async => mockHttpResponse);
-      when(() => mockHttpResponse.statusCode).thenReturn(200);
-
-      final matomoDispatcher = MatomoDispatcher(
-        matomoDispatcherBaseUrl,
-        matomoDispatcherToken,
-        httpClient: mockHttpClient,
-      );
-
-      await matomoDispatcher.send(mockMatomoEvent);
-
-      verify(
-        () => mockHttpClient.post(
-          any(),
-          headers: any(named: 'headers'),
-        ),
-      );
-    });
-
-    test('it should not throw if something wrong happen in send', () async {
-      when(() => mockHttpClient.post(any(), headers: any(named: 'headers')))
-          .thenAnswer((_) async => throw Exception());
-      when(() => mockHttpResponse.statusCode).thenReturn(200);
-
-      final matomoDispatcher = MatomoDispatcher(
-        matomoDispatcherBaseUrl,
-        matomoDispatcherToken,
-        httpClient: mockHttpClient,
-      );
-
-      await expectLater(matomoDispatcher.send(mockMatomoEvent), completes);
-    });
-
-    test('should use customHeaders from the tracker', () async {
-      when(() => mockMatomoTracker.customHeaders).thenReturn({
-        headerKey: headerValue,
-      });
-
-      final matomoDispatcher = MatomoDispatcher(
-        matomoDispatcherBaseUrl,
-        matomoDispatcherToken,
-        httpClient: mockHttpClient,
-      );
-
-      await matomoDispatcher.send(mockMatomoEvent);
-
-      verify(
-        () => mockHttpClient.post(
-          any(),
-          headers: any(
-            named: 'headers',
-            that: containsPair(headerKey, headerValue),
-          ),
-        ),
-      );
-    });
-  });
-
   group('sendBatch', () {
     setUpAll(
       () {
@@ -211,7 +150,7 @@ void main() {
       httpClient: mockHttpClient,
     );
 
-    await matomoDispatcher.send(mockMatomoEvent);
+    await matomoDispatcher.sendBatch([mockMatomoEvent]);
 
     verify(
       () => mockHttpClient.post(


### PR DESCRIPTION
In preparation for the `new_visit` feature I looked through the code an noticed that the `send` method is never used, only `sendBatch`, so I think we should remove it.

This also breaks a test, but the test in question was already "wrong" I guess, since it should have tested `sendBatch` instead of `send`? Anyway, I wasn't able to fix it 😞.