### PR TITLE
Refactor Matomo Event

### DIFF
--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -439,7 +439,6 @@ class MatomoTracker {
 
     validateDimension(dimensions);
     final lastPageView = MatomoEvent(
-      tracker: this,
       action: actionName,
       path: path,
       campaign: campaign,
@@ -466,7 +465,6 @@ class MatomoTracker {
     validateDimension(dimensions);
     return _track(
       MatomoEvent(
-        tracker: this,
         goalId: goalId,
         revenue: revenue,
         dimensions: dimensions,
@@ -488,7 +486,6 @@ class MatomoTracker {
     validateDimension(dimensions);
     return _track(
       MatomoEvent(
-        tracker: this,
         eventInfo: eventInfo,
         screenId: pvId,
         dimensions: dimensions,
@@ -512,7 +509,6 @@ class MatomoTracker {
     validateDimension(dimensions);
     return _track(
       MatomoEvent(
-        tracker: this,
         dimensions: dimensions,
       ),
     );
@@ -533,7 +529,6 @@ class MatomoTracker {
     validateDimension(dimensions);
     return _track(
       MatomoEvent(
-        tracker: this,
         searchKeyword: searchKeyword,
         searchCategory: searchCategory,
         searchCount: searchCount,
@@ -558,7 +553,6 @@ class MatomoTracker {
     validateDimension(dimensions);
     return _track(
       MatomoEvent(
-        tracker: this,
         goalId: 0,
         trackingOrderItems: trackingOrderItems,
         subTotal: subTotal,
@@ -588,7 +582,6 @@ class MatomoTracker {
     validateDimension(dimensions);
     return _track(
       MatomoEvent(
-        tracker: this,
         goalId: 0,
         orderId: orderId,
         trackingOrderItems: trackingOrderItems,
@@ -614,7 +607,6 @@ class MatomoTracker {
     validateDimension(dimensions);
     return _track(
       MatomoEvent(
-        tracker: this,
         link: link,
         dimensions: dimensions,
       ),
@@ -637,7 +629,6 @@ class MatomoTracker {
   }) {
     return _track(
       MatomoEvent(
-        tracker: this,
         content: content,
         screenId: pvId,
         dimensions: dimensions,
@@ -665,7 +656,6 @@ class MatomoTracker {
   }) {
     return _track(
       MatomoEvent(
-        tracker: this,
         content: content,
         contentInteraction: interaction,
         screenId: pvId,
@@ -705,7 +695,7 @@ class MatomoTracker {
       return _lock.synchronized(() async {
         final events = List<MatomoEvent>.from(queue);
         if (!_optOut) {
-          final hasSucceeded = await _dispatcher.sendBatch(events);
+          final hasSucceeded = await _dispatcher.sendBatch(events, this);
           if (hasSucceeded) {
             // As the operation is asynchronous we need to be sure to remove
             // only the events that were sent in the batch.

--- a/lib/src/matomo_dispatcher.dart
+++ b/lib/src/matomo_dispatcher.dart
@@ -26,7 +26,9 @@ class MatomoDispatcher {
   ///
   /// Returns `true` if the batch was sent successfully.
   Future<bool> sendBatch(
-      List<MatomoEvent> events, MatomoTracker tracker) async {
+    List<MatomoEvent> events,
+    MatomoTracker tracker,
+  ) async {
     if (events.isEmpty) return true;
 
     final userAgent = tracker.userAgent;

--- a/lib/src/matomo_event.dart
+++ b/lib/src/matomo_event.dart
@@ -8,7 +8,6 @@ import 'package:matomo_tracker/utils/extensions.dart';
 
 class MatomoEvent {
   MatomoEvent({
-    required this.tracker,
     this.path,
     this.action,
     this.eventInfo,
@@ -40,7 +39,6 @@ class MatomoEvent {
           'screenId has to be six characters long',
         );
 
-  final MatomoTracker tracker;
   final String? path;
 
   /// The title of the action being tracked. It is possible to use slashes / to
@@ -95,7 +93,6 @@ class MatomoEvent {
   final PerformanceInfo? performanceInfo;
 
   MatomoEvent copyWith({
-    MatomoTracker? tracker,
     String? path,
     String? action,
     EventInfo? eventInfo,
@@ -121,7 +118,6 @@ class MatomoEvent {
     PerformanceInfo? performanceInfo,
   }) =>
       MatomoEvent(
-        tracker: tracker ?? this.tracker,
         path: path ?? this.path,
         action: action ?? this.action,
         eventInfo: eventInfo ?? this.eventInfo,
@@ -147,7 +143,7 @@ class MatomoEvent {
         performanceInfo: performanceInfo ?? this.performanceInfo,
       );
 
-  Map<String, String> toMap() {
+  Map<String, String> toMap(MatomoTracker tracker) {
     final id = tracker.visitor.id;
     final uid = tracker.visitor.uid;
     final pvId = screenId;

--- a/test/src/matomo_dispatcher_test.dart
+++ b/test/src/matomo_dispatcher_test.dart
@@ -12,8 +12,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(Uri());
-    when(mockMatomoEvent.toMap).thenReturn({});
-    when(() => mockMatomoEvent.tracker).thenReturn(mockMatomoTracker);
+    when(() => mockMatomoEvent.toMap(mockMatomoTracker)).thenReturn({});
     when(() => mockMatomoTracker.userAgent).thenReturn(null);
     when(() => mockMatomoTracker.log).thenReturn(Logger());
     when(() => mockMatomoTracker.customHeaders).thenReturn({});
@@ -40,7 +39,8 @@ void main() {
         httpClient: mockHttpClient,
       );
 
-      await matomoDispatcher.sendBatch([mockMatomoEvent, mockMatomoEvent]);
+      await matomoDispatcher
+          .sendBatch([mockMatomoEvent, mockMatomoEvent], mockMatomoTracker);
 
       verify(
         () => mockHttpClient.post(
@@ -55,7 +55,6 @@ void main() {
         'it should add user agent in http request if the first event has an user agent',
         () async {
       final events = [mockMatomoEvent, mockMatomoEvent];
-      when(() => events.first.tracker).thenReturn(mockMatomoTracker);
       when(() => mockMatomoTracker.userAgent)
           .thenReturn(matomoTrackerUserAgent);
 
@@ -65,7 +64,7 @@ void main() {
         httpClient: mockHttpClient,
       );
 
-      await matomoDispatcher.sendBatch(events);
+      await matomoDispatcher.sendBatch(events, mockMatomoTracker);
 
       verify(
         () => mockHttpClient.post(
@@ -91,7 +90,7 @@ void main() {
         httpClient: mockHttpClient,
       );
 
-      await matomoDispatcher.sendBatch([]);
+      await matomoDispatcher.sendBatch([], mockMatomoTracker);
 
       verifyNever(
         () => mockHttpClient.post(
@@ -119,7 +118,8 @@ void main() {
     );
 
     await expectLater(
-      matomoDispatcher.sendBatch([mockMatomoEvent, mockMatomoEvent]),
+      matomoDispatcher
+          .sendBatch([mockMatomoEvent, mockMatomoEvent], mockMatomoTracker),
       completes,
     );
   });
@@ -131,7 +131,8 @@ void main() {
       httpClient: mockHttpClient,
     );
 
-    final uri = matomoDispatcher.buildUriForEvent(mockMatomoEvent);
+    final uri =
+        matomoDispatcher.buildUriForEvent(mockMatomoEvent, mockMatomoTracker);
 
     expect(
       uri.queryParameters[MatomoDispatcher.tokenAuthUriKey],
@@ -150,7 +151,7 @@ void main() {
       httpClient: mockHttpClient,
     );
 
-    await matomoDispatcher.sendBatch([mockMatomoEvent]);
+    await matomoDispatcher.sendBatch([mockMatomoEvent], mockMatomoTracker);
 
     verify(
       () => mockHttpClient.post(

--- a/test/src/matomo_event_test.dart
+++ b/test/src/matomo_event_test.dart
@@ -14,7 +14,6 @@ import '../ressources/mock/mock.dart';
 void main() {
   MatomoEvent getCompleteMatomoEvent() {
     return MatomoEvent(
-      tracker: mockMatomoTracker,
       path: matomoEventPath,
       action: matomoEventAction,
       dimensions: matomoEventDimension,
@@ -69,7 +68,6 @@ void main() {
   test('it should be able to create MatomotoEvent', () async {
     final matomotoEvent = getCompleteMatomoEvent();
 
-    expect(matomotoEvent.tracker, mockMatomoTracker);
     expect(matomotoEvent.path, matomoEventPath);
     expect(matomotoEvent.action, matomoEventAction);
     expect(matomotoEvent.eventInfo?.category, matomoEventCategory);
@@ -129,7 +127,6 @@ void main() {
         () {
           MatomoEvent getMatomoEventWithWrongScreenId() {
             return MatomoEvent(
-              tracker: mockMatomoTracker,
               screenId: matomoWrongScreenId,
             );
           }
@@ -146,7 +143,6 @@ void main() {
         () {
           MatomoEvent getMatomoEventWithEmptyEventCategory() {
             return MatomoEvent(
-              tracker: mockMatomoTracker,
               eventInfo: EventInfo(
                 category: '',
                 action: matomoEventAction,
@@ -166,7 +162,6 @@ void main() {
         () {
           MatomoEvent getMatomoEventWithEmptyEventAction() {
             return MatomoEvent(
-              tracker: mockMatomoTracker,
               eventInfo: EventInfo(
                 category: matomoEventCategory,
                 action: '',
@@ -184,7 +179,6 @@ void main() {
       test('it should throw ArgumentError if event name is empty', () {
         MatomoEvent getMatomoEventWithEmptyEventName() {
           return MatomoEvent(
-            tracker: mockMatomoTracker,
             eventInfo: EventInfo(
               category: matomoEventCategory,
               action: matomoEventAction,
@@ -223,7 +217,7 @@ void main() {
 
       withClock(Clock.fixed(fixedDate), () {
         final matomotoEvent = getCompleteMatomoEvent();
-        final eventMap = matomotoEvent.toMap();
+        final eventMap = matomotoEvent.toMap(mockMatomoTracker);
         final wantedEvent = getWantedEventMap(fixedDate);
 
         eventMap.remove('rand');
@@ -243,7 +237,7 @@ void main() {
 
       withClock(Clock.fixed(fixedDate), () {
         final matomotoEvent = getCompleteMatomoEvent();
-        final eventMap = matomotoEvent.toMap();
+        final eventMap = matomotoEvent.toMap(mockMatomoTracker);
         final wantedEvent =
             getWantedEventMap(fixedDate, userAgent: matomoTrackerUserAgent);
 
@@ -279,7 +273,6 @@ void main() {
         final matomotoEvent = getCompleteMatomoEvent();
         final unchangedCopy = matomotoEvent.copyWith();
 
-        expect(matomotoEvent.tracker, unchangedCopy.tracker);
         expect(matomotoEvent.path, unchangedCopy.path);
         expect(matomotoEvent.action, unchangedCopy.action);
         expect(
@@ -356,7 +349,6 @@ void main() {
         final changedCopy =
             matomotoEvent.copyWith(newVisit: matomoChangedNewVisit);
 
-        expect(matomotoEvent.tracker, changedCopy.tracker);
         expect(matomotoEvent.path, changedCopy.path);
         expect(matomotoEvent.action, changedCopy.action);
         expect(
@@ -444,7 +436,7 @@ void main() {
 
     test('it should have ca if its an event or content and not a ping',
         () async {
-      final matomotoMap = getCompleteMatomoEvent().toMap();
+      final matomotoMap = getCompleteMatomoEvent().toMap(mockMatomoTracker);
 
       expect(matomotoMap['ca'], '1');
     });
@@ -454,7 +446,7 @@ void main() {
           .copyWith(
             ping: true,
           )
-          .toMap();
+          .toMap(mockMatomoTracker);
 
       expect(matomotoMap.containsKey('ca'), false);
     });
@@ -464,7 +456,7 @@ void main() {
           .copyWith(
             ping: true,
           )
-          .toMap();
+          .toMap(mockMatomoTracker);
 
       expect(matomotoMap.containsKey('pf_net'), false);
       expect(matomotoMap.containsKey('pf_srv'), false);


### PR DESCRIPTION
Currently, the internal `MatomoEvent` class has a field `tracker` containing a reference to the tracker that created that event.
In my opinion, the `MatomoEvent` should be a pure data object, thus, it should not have references to non-data objects.

From a code perspective, the `tracker` is not needed for the most part of the object, only when it comes to serialization using `toMap` for dispatching the object, but at that time, the caller of `toMap` should be responsible to provide these additional information.