### PR TITLE
Ability to drop the Dispatch Queue

### DIFF
--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -354,9 +354,14 @@ class MatomoTracker {
     }
   }
 
-  /// Iterate on the events in the queue and send them to Matomo.
-  FutureOr<void> dispatchEvents() {
+  /// Iterate on the actions in the queue and send them to Matomo.
+  FutureOr<void> dispatchActions() {
     return _dequeue();
+  }
+
+  /// Drops all actions queued for dispatching.
+  void dropActions() {
+    queue.clear();
   }
 
   /// This will register a page view with [trackScreenWithName] by using the

--- a/test/src/matomo_test.dart
+++ b/test/src/matomo_test.dart
@@ -138,13 +138,23 @@ void main() {
     });
   });
 
-  test('it should be able to dispatchEvents', () async {
+  test('it should be able to dispatchActions', () async {
     final matomoTracker = await getInitializedMatomoTracker();
     final queueLength = matomoTracker.queue.length;
 
     matomoTracker.trackDimensions(matomoTrackerDimensions);
     expect(matomoTracker.queue.length, queueLength + 1);
-    await matomoTracker.dispatchEvents();
+    await matomoTracker.dispatchActions();
+    expect(matomoTracker.queue.length, 0);
+  });
+
+  test('it should be able to dropActions', () async {
+    final matomoTracker = await getInitializedMatomoTracker();
+    final queueLength = matomoTracker.queue.length;
+
+    matomoTracker.trackDimensions(matomoTrackerDimensions);
+    expect(matomoTracker.queue.length, queueLength + 1);
+    matomoTracker.dropActions();
     expect(matomoTracker.queue.length, 0);
   });
 


### PR DESCRIPTION
I added `dropActions` to manually clear the dispatch queue.

I also renamed `dispatchEvents` to `dispatchActions`, because technically, those are actions and not only events (events are a subtype of actions) and I wanted to lower the confusion potential by using the correct Matomo nomenclature.

Also, can someone explain why the return type of (now) `dispatchActions` and `_dequeue` is `FutureOr` and not simply `Future`?