### PR TITLE
Option to attach the last pvId automatically

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -52,15 +52,12 @@ class MyHomePageState extends State<MyHomePage> with TraceableClientMixin {
 
   void _incrementCounter() {
     // Send an event to Matomo on tap.
-    // To signal that this event happend on this page, we use the
-    // pvId of the page.
     MatomoTracker.instance.trackEvent(
       eventInfo: EventInfo(
         category: 'Main',
         action: 'Click',
         name: 'IncrementCounter',
       ),
-      pvId: pvId,
     );
     setState(() {
       _counter++;
@@ -77,9 +74,7 @@ class MyHomePageState extends State<MyHomePage> with TraceableClientMixin {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            ContentWidget(
-              pvId: pvId,
-            ),
+            const ContentWidget(),
             const Text(
               'You have pushed the button this many times:',
             ),
@@ -190,10 +185,8 @@ class OtherPage2 extends StatelessWidget {
 }
 
 class ContentWidget extends StatefulWidget {
-  final String? pvId;
   const ContentWidget({
     super.key,
-    this.pvId,
   });
 
   @override
@@ -213,7 +206,6 @@ class _ContentWidgetState extends State<ContentWidget> {
     _closed = false;
     MatomoTracker.instance.trackContentImpression(
       content: _exampleContent,
-      pvId: widget.pvId,
     );
   }
 
@@ -253,7 +245,6 @@ class _ContentWidgetState extends State<ContentWidget> {
     MatomoTracker.instance.trackContentInteraction(
       interaction: 'close',
       content: _exampleContent,
-      pvId: widget.pvId,
     );
   }
 }

--- a/lib/matomo_tracker.dart
+++ b/lib/matomo_tracker.dart
@@ -1,3 +1,5 @@
+/// A fully cross-platform wrap of the Matomo [Tracking HTTP API](https://developer.matomo.org/api-reference/tracking-api)
+/// for Flutter.
 library matomo_tracker;
 
 export 'src/campaign.dart';

--- a/lib/src/assert.dart
+++ b/lib/src/assert.dart
@@ -2,7 +2,10 @@
 /// only.
 ///
 /// If the passed [value] is null, it won't do anything.
-void assertStringIsFilled({required String? value, required String name}) {
+void assertStringIsFilled({
+  required String? value,
+  required String name,
+}) {
   if (value != null && value.trim().isEmpty) {
     throw ArgumentError.value(
       value,
@@ -15,7 +18,10 @@ void assertStringIsFilled({required String? value, required String name}) {
 /// Method used to assert that a duration is not negative.
 ///
 /// If the passed [value] is null, it won't do anything.
-void assertDurationNotNegative({required Duration? value, required String name}) {
+void assertDurationNotNegative({
+  required Duration? value,
+  required String name,
+}) {
   if (value != null && value.isNegative) {
     throw ArgumentError.value(
       value,

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -145,7 +145,9 @@ class MatomoTracker {
   ///
   /// The [visitorId] should have a length of 16 characters otherwise an
   /// [ArgumentError] will be thrown. This parameter corresponds with the
-  /// `_id` and should not be confused with the user id `uid`.
+  /// `_id` and should not be confused with the user id `uid`. See the
+  /// [Visitor] class for additional remarks. It is recommended to leave this
+  /// to `null` to use an automatically generated id.
   ///
   /// If [cookieless] is set to true, a [CookielessStorage] instance will be
   /// used. This means that the first_visit and the user_id will be stored in

--- a/lib/src/matomo_action.dart
+++ b/lib/src/matomo_action.dart
@@ -216,7 +216,7 @@ class MatomoAction {
       'cookie': '1',
       if (ua != null) 'ua': ua,
       'lang': locale.toString(),
-      if (country != null && tracker.getAuthToken != null) 'country': country,
+      if (country != null && tracker.authToken != null) 'country': country,
 
       if (uid != null) 'uid': uid,
 

--- a/lib/src/matomo_dispatcher.dart
+++ b/lib/src/matomo_dispatcher.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
-import 'package:matomo_tracker/src/matomo_action.dart';
 import 'package:matomo_tracker/src/logger/logger.dart';
 
 class MatomoDispatcher {

--- a/lib/src/traceable_widget_mixin.dart
+++ b/lib/src/traceable_widget_mixin.dart
@@ -19,7 +19,11 @@ mixin TraceableClientMixin<T extends StatefulWidget> on State<T>
   ///
   /// Each unique ID represents one page view.
   ///
-  /// The default implementation will generate one on widget creation.
+  /// The default implementation will generate one on widget creation
+  /// (recommended).
+  ///
+  /// For more information see `pvId` in [MatomoTracker.trackScreenWithName] and
+  /// [MatomoTracker.attachLastPvId].
   /// {@endtemplate}
   @protected
   String get pvId => _pvId;

--- a/lib/src/visitor.dart
+++ b/lib/src/visitor.dart
@@ -20,13 +20,22 @@ class Visitor {
 
   /// The unique visitor ID, must be a 16 characters hexadecimal string.
   ///
+  /// Corresponds with `_id`.
+  ///
   /// Every unique visitor must be assigned a different ID and this ID must not
   /// change after it is assigned. If this value is not set Matomo will still
   /// track visits, but the unique visitors metric might be less accurate.
+  ///
+  /// Think of this as a device ID; in case of website tracking (where Matomo
+  /// originates), this would be the cookie identifying the browser and not
+  /// necessarily a user (since a single browser might be used by multiple
+  /// users).
   final String? id;
 
-  /// [User ID](https://matomo.org/guide/reports/user-ids/) is any non-empty
+  /// The [User ID](https://matomo.org/guide/reports/user-ids/) is any non-empty
   /// unique string identifying the user (such as an email address or an
   /// username).
+  ///
+  /// Corresponds with `uid`.
   final String? uid;
 }

--- a/test/ressources/mock/mock.dart
+++ b/test/ressources/mock/mock.dart
@@ -2,6 +2,7 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:matomo_tracker/src/local_storage/local_storage.dart';
+import 'package:matomo_tracker/src/logger/logger.dart';
 import 'package:matomo_tracker/src/matomo.dart';
 import 'package:matomo_tracker/src/matomo_action.dart';
 import 'package:matomo_tracker/src/platform_info/platform_info.dart';
@@ -49,6 +50,8 @@ class MockLinuxDeviceInfo extends Mock implements LinuxDeviceInfo {}
 
 class MockBuildContext extends Mock implements BuildContext {}
 
+class MockLogger extends Mock implements Logger {}
+
 // used to mock widgets
 class MockWidget extends StatelessWidget {
   const MockWidget({super.key});
@@ -78,3 +81,4 @@ final mockMacOsDeviceInfo = MockMacOsDeviceInfo();
 final mockLinuxDeviceInfo = MockLinuxDeviceInfo();
 final mockPackageInfo = MockPackageInfo();
 final mockBuildContext = MockBuildContext();
+final mockLogger = MockLogger();

--- a/test/src/matomo_dispatcher_test.dart
+++ b/test/src/matomo_dispatcher_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:matomo_tracker/src/logger/logger.dart';
 import 'package:matomo_tracker/src/matomo_dispatcher.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -14,7 +13,7 @@ void main() {
     registerFallbackValue(Uri());
     when(() => mockMatomoAction.toMap(mockMatomoTracker)).thenReturn({});
     when(() => mockMatomoTracker.userAgent).thenReturn(null);
-    when(() => mockMatomoTracker.log).thenReturn(Logger());
+    when(() => mockMatomoTracker.log).thenReturn(mockLogger);
     when(() => mockMatomoTracker.customHeaders).thenReturn({});
   });
 
@@ -34,13 +33,18 @@ void main() {
 
     test('it should be able to send MatomoAction in batch', () async {
       final matomoDispatcher = MatomoDispatcher(
-        matomoDispatcherBaseUrl,
-        matomoDispatcherToken,
+        baseUrl: matomoDispatcherBaseUrl,
+        userAgent: matomoTrackerUserAgent,
+        tokenAuth: matomoDispatcherToken,
         httpClient: mockHttpClient,
+        log: mockLogger,
       );
 
-      await matomoDispatcher
-          .sendBatch([mockMatomoAction, mockMatomoAction], mockMatomoTracker);
+      await matomoDispatcher.sendBatch(
+        actions: [mockMatomoAction, mockMatomoAction]
+            .map((action) => action.toMap(mockMatomoTracker))
+            .toList(),
+      );
 
       verify(
         () => mockHttpClient.post(
@@ -51,20 +55,21 @@ void main() {
       );
     });
 
-    test(
-        'it should add user agent in http request if the first action has an user agent',
-        () async {
+    test('it should set user agent in http request', () async {
       final actions = [mockMatomoAction, mockMatomoAction];
-      when(() => mockMatomoTracker.userAgent)
-          .thenReturn(matomoTrackerUserAgent);
 
       final matomoDispatcher = MatomoDispatcher(
-        matomoDispatcherBaseUrl,
-        matomoDispatcherToken,
+        baseUrl: matomoDispatcherBaseUrl,
+        userAgent: matomoTrackerUserAgent,
+        tokenAuth: matomoDispatcherToken,
         httpClient: mockHttpClient,
+        log: mockLogger,
       );
 
-      await matomoDispatcher.sendBatch(actions, mockMatomoTracker);
+      await matomoDispatcher.sendBatch(
+        actions: actions.map((action) => action.toMap(mockMatomoTracker)).toList(),
+        customHeaders: mockMatomoTracker.customHeaders,
+      );
 
       verify(
         () => mockHttpClient.post(
@@ -85,12 +90,17 @@ void main() {
         'it should send nothing in sendBatch if the list of MatomoAction is empty',
         () async {
       final matomoDispatcher = MatomoDispatcher(
-        matomoDispatcherBaseUrl,
-        matomoDispatcherToken,
+        baseUrl: matomoDispatcherBaseUrl,
+        userAgent: matomoTrackerUserAgent,
+        tokenAuth: matomoDispatcherToken,
         httpClient: mockHttpClient,
+        log: mockLogger,
       );
 
-      await matomoDispatcher.sendBatch([], mockMatomoTracker);
+      await matomoDispatcher.sendBatch(
+        actions: [],
+        customHeaders: mockMatomoTracker.customHeaders,
+      );
 
       verifyNever(
         () => mockHttpClient.post(
@@ -112,31 +122,56 @@ void main() {
       ),
     ).thenAnswer((_) async => throw Exception());
     final matomoDispatcher = MatomoDispatcher(
-      matomoDispatcherBaseUrl,
-      matomoDispatcherToken,
+      baseUrl: matomoDispatcherBaseUrl,
+      userAgent: matomoTrackerUserAgent,
+      tokenAuth: matomoDispatcherToken,
       httpClient: mockHttpClient,
+      log: mockLogger,
     );
 
     await expectLater(
-      matomoDispatcher
-          .sendBatch([mockMatomoAction, mockMatomoAction], mockMatomoTracker),
-      completes,
+      matomoDispatcher.sendBatch(
+        actions: [mockMatomoAction, mockMatomoAction]
+            .map((action) => action.toMap(mockMatomoTracker))
+            .toList(),
+        customHeaders: mockMatomoTracker.customHeaders,
+      ),
+	  completes,
     );
   });
 
-  test("it should add the tokenAuth to Uri if it's not null", () {
+  test('it should add the tokenAuth to Uri if it is not null', () {
     final matomoDispatcher = MatomoDispatcher(
-      matomoDispatcherBaseUrl,
-      matomoDispatcherToken,
+      baseUrl: matomoDispatcherBaseUrl,
+      userAgent: matomoTrackerUserAgent,
+      tokenAuth: matomoDispatcherToken,
       httpClient: mockHttpClient,
+      log: mockLogger,
     );
 
-    final uri =
-        matomoDispatcher.buildUriForAction(mockMatomoAction, mockMatomoTracker);
+    final uri = matomoDispatcher
+        .buildUriForAction(mockMatomoAction.toMap(mockMatomoTracker));
 
     expect(
       uri.queryParameters[MatomoDispatcher.tokenAuthUriKey],
       matomoDispatcherToken,
+    );
+  });
+
+  test('it should not add the tokenAuth to Uri if it is null', () {
+    final matomoDispatcher = MatomoDispatcher(
+      baseUrl: matomoDispatcherBaseUrl,
+      userAgent: matomoTrackerUserAgent,
+      httpClient: mockHttpClient,
+      log: mockLogger,
+    );
+
+    final uri = matomoDispatcher
+        .buildUriForAction(mockMatomoAction.toMap(mockMatomoTracker));
+
+    expect(
+      uri.queryParameters.containsKey(MatomoDispatcher.tokenAuthUriKey),
+      false,
     );
   });
 
@@ -146,12 +181,17 @@ void main() {
     });
 
     final matomoDispatcher = MatomoDispatcher(
-      matomoDispatcherBaseUrl,
-      matomoDispatcherToken,
+      baseUrl: matomoDispatcherBaseUrl,
+      userAgent: matomoTrackerUserAgent,
+      tokenAuth: matomoDispatcherToken,
       httpClient: mockHttpClient,
+      log: mockLogger,
     );
 
-    await matomoDispatcher.sendBatch([mockMatomoAction], mockMatomoTracker);
+    await matomoDispatcher.sendBatch(
+      actions: [mockMatomoAction].map((action) => action.toMap(mockMatomoTracker)).toList(),
+      customHeaders: mockMatomoTracker.customHeaders,
+    );
 
     verify(
       () => mockHttpClient.post(

--- a/test/src/matomo_dispatcher_test.dart
+++ b/test/src/matomo_dispatcher_test.dart
@@ -67,7 +67,8 @@ void main() {
       );
 
       await matomoDispatcher.sendBatch(
-        actions: actions.map((action) => action.toMap(mockMatomoTracker)).toList(),
+        actions:
+            actions.map((action) => action.toMap(mockMatomoTracker)).toList(),
         customHeaders: mockMatomoTracker.customHeaders,
       );
 
@@ -136,7 +137,7 @@ void main() {
             .toList(),
         customHeaders: mockMatomoTracker.customHeaders,
       ),
-	  completes,
+      completes,
     );
   });
 
@@ -189,7 +190,9 @@ void main() {
     );
 
     await matomoDispatcher.sendBatch(
-      actions: [mockMatomoAction].map((action) => action.toMap(mockMatomoTracker)).toList(),
+      actions: [mockMatomoAction]
+          .map((action) => action.toMap(mockMatomoTracker))
+          .toList(),
       customHeaders: mockMatomoTracker.customHeaders,
     );
 

--- a/test/src/matomo_test.dart
+++ b/test/src/matomo_test.dart
@@ -82,7 +82,7 @@ void main() {
 
     testInitialization(
       'it should be able to set tokenAuth',
-      [(tracker, _) => expect(tracker.getAuthToken, matomoTrackerTokenAuth)],
+      [(tracker, _) => expect(tracker.authToken, matomoTrackerTokenAuth)],
       tokenAuth: matomoTrackerTokenAuth,
     );
   });
@@ -261,9 +261,9 @@ void main() {
       final matomoTracker = await getInitializedMatomoTracker();
 
       matomoTracker.trackDimensions(matomoTrackerDimensions);
-      expect(matomoTracker.queue.first.newVisit, true);
+      expect(matomoTracker.queue.first['new_visit'], '1');
       matomoTracker.trackDimensions(matomoTrackerDimensions);
-      expect(matomoTracker.queue.last.newVisit, null);
+      expect(matomoTracker.queue.last.containsKey('new_visit'), false);
     });
   });
 


### PR DESCRIPTION
I think the documentation of `attachLastPvId` describes this PR pretty good:
```dart
  /// Whether to attach the last `pvId` to actions that can be associated with
  /// page views.
  ///
  /// There are some actions like [trackEvent] and [trackContentImpression]
  /// that can be associated with page views by setting a `pvId` (what is the
  /// abbreviation of page view id). If [attachLastPvId] is `true` and there is
  /// a last page view tracked by [trackScreenWithName] (or a method/class that
  /// uses it like [trackScreen], [TraceableClientMixin], [TraceableWidget]) the
  /// last recored `pvId` is automatically used unless it is overwritten in that
  /// action.
  late final bool attachLastPvId;
```