### PR TITLE
More campaigns, path, pvId

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -171,28 +171,6 @@ class _OtherPageState extends State<OtherPage> {
   }
 }
 
-class OtherPage2 extends StatelessWidget {
-  const OtherPage2({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return TraceableWidget(
-      path: '/otherpage',
-      actionName: 'Other Page',
-      child: Scaffold(
-        appBar: AppBar(
-          title: const Text('Other Page'),
-        ),
-        body: const Center(
-          child: Text(
-            'Welcome to the other page!',
-          ),
-        ),
-      ),
-    );
-  }
-}
-
 class ContentWidget extends StatefulWidget {
   const ContentWidget({
     super.key,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 // See the docker folder for instructions on how to get a
 // test Matomo instance running
@@ -105,6 +106,8 @@ class MyHomePageState extends State<MyHomePage> with TraceableClientMixin {
                 child: const Text('Go to OtherPage'),
               ),
             ),
+            const Outlink(),
+            const SearchWidget(),
           ],
         ),
       ),
@@ -168,6 +171,108 @@ class _OtherPageState extends State<OtherPage> {
               ),
       ),
     );
+  }
+}
+
+/// Example for outlink tracking
+class Outlink extends StatelessWidget {
+  static const _outlink = 'https://github.com/Floating-Dartists/matomo-tracker';
+  const Outlink({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 15.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text('Outlink tracking test:'),
+          ElevatedButton(
+            onPressed: _onPressed,
+            child: const Text('View on GitHub'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _onPressed() {
+    MatomoTracker.instance.trackOutlink(
+      link: _outlink,
+    );
+    launchUrl(Uri.parse(_outlink));
+  }
+}
+
+class SearchWidget extends StatefulWidget {
+  const SearchWidget({super.key});
+
+  @override
+  State<SearchWidget> createState() => _SearchWidgetState();
+}
+
+class _SearchWidgetState extends State<SearchWidget> {
+  final _searchController = TextEditingController(text: 'Enter Search Text...');
+  bool _canSearch = true;
+  String? _lastSearch;
+
+  @override
+  void initState() {
+    super.initState();
+    _searchController.addListener(_textChange);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _searchController.removeListener(_textChange);
+  }
+
+  void _textChange() {
+    final canSearch = _searchController.text.trim().isNotEmpty;
+    if (_canSearch != canSearch) {
+      setState(() {
+        _canSearch = canSearch;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 15.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 10.0),
+                width: 300.0,
+                child: TextField(controller: _searchController),
+              ),
+              IconButton(
+                onPressed: _canSearch ? _search : null,
+                icon: const Icon(Icons.search),
+              ),
+            ],
+          ),
+          _lastSearch == null
+              ? const Text('No search yet!')
+              : Text('Last search: $_lastSearch'),
+        ],
+      ),
+    );
+  }
+
+  void _search() {
+    MatomoTracker.instance.trackSearch(
+      searchKeyword: _searchController.text,
+    );
+    setState(() {
+      _lastSearch = _searchController.text;
+    });
   }
 }
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
   matomo_tracker:
     path: ..
+  url_launcher: ^6.1.11
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/campaign.dart
+++ b/lib/src/campaign.dart
@@ -2,6 +2,17 @@ import 'package:matomo_tracker/src/assert.dart';
 
 /// Describes a campaign.
 ///
+/// Multiple `track...` methods in [MatomoTracker] can take a campaign as argument.
+/// 
+/// When using campaigns, it should be noted that each visit can only have at most
+/// one campaign associated with it. It does not matter if the first `track...`
+/// call or a subsequent `track...` call has the campaign attached, it will be treated
+/// as the campaign for the whole visit. Calling `track...` methods with the same
+/// campaign (in respect to the objects field values) will not start a new visit,
+/// nor will calling `track...` without a campaign after setting a campaign in a
+/// previous `track...` call start a new visit. On the other hand, calling a
+/// `track...` method with a different campaign will start a new visit.
+///
 /// Read more about [Campaign Tracking](https://matomo.org/faq/reports/what-is-campaign-tracking-and-why-it-is-important/).
 class Campaign {
   /// Creates a campaign description.

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -477,7 +477,7 @@ class MatomoTracker {
   ///
   /// - `campaign`: The campaign that lead to this page view.
   ///
-  /// {@template dimensions_track_parameter}
+  /// {@macro dimensions_track_parameter}
   ///
   /// {@macro new_visit_track_parameter}
   void trackScreenWithName({
@@ -517,7 +517,7 @@ class MatomoTracker {
   ///
   /// The [id] corresponds with `idgoal` and [revenue] with `revenue`.
   ///
-  /// {@template dimensions_track_parameter}
+  /// {@macro dimensions_track_parameter}
   ///
   /// {@macro new_visit_track_parameter}
   void trackGoal({
@@ -546,7 +546,7 @@ class MatomoTracker {
   /// manually, e.g. [TraceableClientMixin.pvId]. Setting [pvId] manually will
   /// take precedance over [attachLastPvId].
   ///
-  /// {@template dimensions_track_parameter}
+  /// {@macro dimensions_track_parameter}
   ///
   /// {@macro new_visit_track_parameter}
   void trackEvent({
@@ -601,7 +601,7 @@ class MatomoTracker {
   /// [searchKeyword] corresponds with `search`, [searchCategory] with
   /// `search_cat` and [searchCount] with `search_count`.
   ///
-  /// {@template dimensions_track_parameter}
+  /// {@macro dimensions_track_parameter}
   ///
   /// {@macro new_visit_track_parameter}
   void trackSearch({
@@ -625,7 +625,7 @@ class MatomoTracker {
 
   /// Tracks a cart update.
   ///
-  /// {@template dimensions_track_parameter}
+  /// {@macro dimensions_track_parameter}
   ///
   /// {@macro new_visit_track_parameter}
   void trackCartUpdate({
@@ -661,7 +661,7 @@ class MatomoTracker {
   /// [revenue] with `revenue`, [subTotal] with `ec_st`, [taxAmount] with
   /// `ec_tx`, [shippingCost] with `ec_sh`, [discountAmount] with `ec_dt`.
   ///
-  /// {@template dimensions_track_parameter}
+  /// {@macro dimensions_track_parameter}
   ///
   /// {@macro new_visit_track_parameter}
   void trackOrder({
@@ -699,7 +699,7 @@ class MatomoTracker {
   ///
   /// [link] corresponds with `link`.
   ///
-  /// {@template dimensions_track_parameter}
+  /// {@macro dimensions_track_parameter}
   ///
   /// {@macro new_visit_track_parameter}
   void trackOutlink({
@@ -729,7 +729,7 @@ class MatomoTracker {
   /// manually, e.g. [TraceableClientMixin.pvId]. Setting [pvId] manually will
   /// take precedance over [attachLastPvId].
   ///
-  /// {@template dimensions_track_parameter}
+  /// {@macro dimensions_track_parameter}
   ///
   /// {@macro new_visit_track_parameter}
   void trackContentImpression({
@@ -761,7 +761,7 @@ class MatomoTracker {
   /// view manually, e.g. [TraceableClientMixin.pvId]. Setting [pvId] manually
   /// will take precedance over [attachLastPvId].
   ///
-  /// {@template dimensions_track_parameter}
+  /// {@macro dimensions_track_parameter}
   ///
   /// Note that this method is missing a `newVisit` parameter on purpose since
   /// it doesn't make sense to have an interaction without an impression first,

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -583,10 +583,7 @@ class MatomoTracker {
   /// in the [Tracking HTTP API](https://developer.matomo.org/api-reference/tracking-api)
   /// documentation.
   ///
-  /// The [newVisit] parameter can be used to make this action the begin
-  /// of a new visit. If it's left to `null` and this is the first `track...`
-  /// call after [MatomoTracker.initialize], the `newVisit` from there will
-  /// be used.
+  /// {@macro new_visit_track_parameter}
   void trackDimensions({
     required Map<String, String> dimensions,
     bool? newVisit,

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -425,10 +425,12 @@ class MatomoTracker {
   /// a random id will be generated (recommended). Also see [attachLastPvId].
   ///
   /// - `path`: A string that identifies the path of the screen. If not
-  /// `null`, it will be combined to [contentBase] to create a URL. This combination
+  /// `null`, it will be appended to [contentBase] to create a URL. This combination
   /// corresponds with `url`.
   ///
-  /// - `campaign`: The campaign that lead to this page view.
+  /// - `campaign`: The campaign that lead to this page view. Setting this multiple
+  /// times during an apps lifetime can have some side effects, see the [Campaign]
+  /// class for more information.
   ///
   /// {@template dimensions_track_parameter}
   /// For remarks on [dimensions] see [trackDimensions].
@@ -472,10 +474,12 @@ class MatomoTracker {
   /// a random id will be generated (recommended). Also see [attachLastPvId].
   ///
   /// - `path`: A string that identifies the path of the screen. If not
-  /// `null`, it will be combined to [contentBase] to create a URL. This
+  /// `null`, it will be appended to [contentBase] to create a URL. This
   /// combination corresponds with `url`.
   ///
-  /// - `campaign`: The campaign that lead to this page view.
+  /// - `campaign`: The campaign that lead to this page view. Setting this multiple
+  /// times during an apps lifetime can have some side effects, see the [Campaign]
+  /// class for more information.
   ///
   /// {@macro dimensions_track_parameter}
   ///

--- a/lib/src/traceable_widget_mixin.dart
+++ b/lib/src/traceable_widget_mixin.dart
@@ -23,7 +23,7 @@ mixin TraceableClientMixin<T extends StatefulWidget> on State<T>
   /// (recommended).
   ///
   /// For more information see `pvId` in [MatomoTracker.trackScreenWithName] and
-  /// [MatomoTracker.attachLastPvId].
+  /// [MatomoTracker.attachLastScreenInfo].
   /// {@endtemplate}
   @protected
   String get pvId => _pvId;

--- a/lib/src/traceable_widget_mixin.dart
+++ b/lib/src/traceable_widget_mixin.dart
@@ -51,7 +51,9 @@ mixin TraceableClientMixin<T extends StatefulWidget> on State<T>
 
   /// {@template traceableClientMixin.campaign}
   /// The campaign that lead to this interaction or `null` for a
-  /// default entry.
+  /// default entry. Setting this multiple times during an apps
+  /// lifetime can have some side effects, see the [Campaign] class
+  /// for more information.
   /// {@endtemplate}
   @protected
   Campaign? campaign;


### PR DESCRIPTION
I did some more research and testing regarding campaigns and added those findings to the documentation.

However, one key learning is that not only page views can have campaigns, but other actions like events or content tracking, too.
In retrospective, this seems only logical, since the campaign settings are encoded in the `url` parameter and it turned out that the `url` parameter is actually used in every `track...` call in the JavaScript Tracker, what kind of supprised me:
* Sure, the [documentation](https://developer.matomo.org/api-reference/tracking-api) recommends setting `url` for every `track...` call, but so does it for `action_name`, and that is a whole different story (see matomo-org/developer-documentation#735).
* From my tests I found out that when setting the `pvId` in e.g. an event tracking call to the `pvId` of a page view, both things are assosiacted with one another correctly, so I didn't think an `url` was needed, and my thought *was* why send it when it's not needed?

But to conclude I *now* think that every `track...` call should have the possibility to set a `campaign` and a `path` (what relates to having an `url` in our case). Imo the `path` is related to the page view (just as `pvId`) but a developer should have the opportunity to manually set it, so my approach was to add the `path` parameter to every `track...` call (with appropriate documentation) and change `attachLastPvId` to `attachLastScreenInfo` so it not only accounts for the automatical attachment of `pvId` but also of `path`. Futhermore I found out, that most `track...` calls can have a `pvId` (until now I thought only event and content tracking can have one), so I added it as parameter. If someone is interested in those additional tests, they can be found [here](https://github.com/EPNW/matomo-tracker/tree/more_tests/more_tests).

I also added search and outlink tracking to the example (because I wanted to see how it looks like in the dashboard), and fixed a small `macro` mistake.

Finally I want to propose to rename `trackScreen` to `trackPageView` and `trackScreenWithName` to `trackPageViewWithName` since the documentation always refers to the thing they track as page views. This would also imply changing `screenId` in `MatomoAction` to `pvId`.