### PR TITLE
refacto: renamed trackScreen methods to trackPageView and fixed linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Contributions from [Eric Prokop](https://github.com/EPNW-Eric)
   * feat: Added a persistent dispatch queue [#97](https://github.com/Floating-Dartists/matomo-tracker/pull/97)
   * feat: Extended the newVisit capabilities [#105](https://github.com/Floating-Dartists/matomo-tracker/pull/105)
+  * feat: More campaigns, path, pvId [#109](https://github.com/Floating-Dartists/matomo-tracker/pull/109)
 * Contributions from [TesteurManiak](https://github.com/TesteurManiak)
   * chore: Updated `LICENSE` with major contributors [#100](https://github.com/Floating-Dartists/matomo-tracker/pull/100)
   * chore: Added a contribution guide [#101](https://github.com/Floating-Dartists/matomo-tracker/pull/101)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ class MyHomePage extends StatelessWidget {
 }
 ```
 
-You can also optionally call directly `trackScreen` or `trackScreenWithName` to track a view.
+You can also optionally call directly `trackPageView` or `trackPageViewWithName` to track a view.
 
 For tracking goals and, events call `trackGoal` and `trackEvent` respectively.
 
@@ -178,7 +178,7 @@ MatomoTracker.instance.trackEvent(
 You can similarly track dimensions on Screen views with:
 
 ```dart
-MatomoTracker.instance.trackScreenWithName(
+MatomoTracker.instance.trackPageViewWithName(
     actionName: "Settings",
     path: "/settings",
     dimensions: {'dimension1': '0.0.1'}
@@ -217,6 +217,7 @@ await MatomoTracker.instance.initialize(
 
 ## v4.0.0
 
+* `trackScreen` was renamed to `trackPageView` and `trackScreenWithName` to `trackPageViewWithName`.
 * `forcedId` property has been removed as it was never used. You should rely on the user ID instead.
 * Occurences of `userId` have been renamed to `uid`.
 * Occurences of `traceName` and `widgetName` have been renamed to `actionName`.
@@ -233,7 +234,7 @@ MaterialApp(
 );
 ```
 * `MatomoEvent` has been renamed to `MatomoAction`
-* `trackScreen` positional parameter `context` is now a named parameter
+* `trackPageView` positional parameter `context` is now a named parameter
 * `trackGoal` positional parameter `goalId` is now a named parameter: `id`
 * `trackDimensions` positional parameter `dimensions` is now a named parameter
 * `trackCartUpdate` positional parameters `trackingOrderItems`, `subTotal`, `taxAmount`, `shippingCost` and `discountAmount` are now named parameters

--- a/README.md
+++ b/README.md
@@ -218,11 +218,11 @@ await MatomoTracker.instance.initialize(
 ## v4.0.0
 
 * `trackScreen` was renamed to `trackPageView` and `trackScreenWithName` to `trackPageViewWithName`.
+* `screenId` and `widgetId` were renamed to `pvId`.
+* `userId` was renamed to `uid`.
+* `traceName` and `widgetName` were renamed to `actionName`.
+* `traceTitle` was renamed to `eventName`.
 * `forcedId` property has been removed as it was never used. You should rely on the user ID instead.
-* Occurences of `userId` have been renamed to `uid`.
-* Occurences of `traceName` and `widgetName` have been renamed to `actionName`.
-* Occurences of `traceTitle` have been renamed to `eventName`.
-* Occurences of `widgetId` have been renamed to `pvId`.
 * An object of type `EventInfo` has been added, it has the following properties: `category`, `action`, `name` and `value`, use it instead of passing the event name, action and value as separate parameters.
 * For `TraceableClientMixin` and `TraceableWidget` to work you will have to add the `matomoObserver` to your `MaterialApp` or `WidgetsApp`:
 ```dart

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:fd_lints/flutter.yaml
+
+analyzer:
+  plugins:
+    - custom_lint

--- a/example/ios/Flutter/Debug.xcconfig
+++ b/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Flutter/Release.xcconfig
+++ b/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,0 +1,44 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '11.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/example/linux/flutter/generated_plugin_registrant.cc
+++ b/example/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/example/macos/Flutter/Flutter-Debug.xcconfig
+++ b/example/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/example/macos/Flutter/Flutter-Release.xcconfig
+++ b/example/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,9 +8,11 @@ import Foundation
 import device_info_plus
 import package_info_plus
 import shared_preferences_foundation
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/example/macos/Podfile
+++ b/example/macos/Podfile
@@ -1,0 +1,43 @@
+platform :osx, '10.14'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/lib/src/local_storage/shared_prefs_storage.dart
+++ b/lib/src/local_storage/shared_prefs_storage.dart
@@ -15,8 +15,7 @@ class SharedPrefsStorage implements LocalStorage {
   set prefs(SharedPreferences prefs) => _prefs = prefs;
 
   Future<SharedPreferences> _getSharedPrefs() async {
-    _prefs ??= await SharedPreferences.getInstance();
-    return _prefs!;
+    return _prefs ??= await SharedPreferences.getInstance();
   }
 
   @override

--- a/lib/src/matomo_action.dart
+++ b/lib/src/matomo_action.dart
@@ -11,7 +11,7 @@ class MatomoAction {
     this.path,
     this.action,
     this.eventInfo,
-    this.screenId,
+    this.pvId,
     this.goalId,
     this.orderId,
     this.trackingOrderItems,
@@ -35,8 +35,8 @@ class MatomoAction {
         // we use clock.now instead of DateTime.now to make testing easier
         _date = clock.now().toUtc(),
         assert(
-          screenId == null || screenId.length == 6,
-          'screenId has to be six characters long',
+          pvId == null || pvId.length == 6,
+          'pvId has to be six characters long',
         );
 
   final String? path;
@@ -50,7 +50,7 @@ class MatomoAction {
 
   /// 6 character unique ID that identifies which actions were performed on a
   /// specific page view.
-  final String? screenId;
+  final String? pvId;
 
   ///  If specified, the tracking request will trigger a conversion for the
   /// [goal](https://matomo.org/guide/reports/goals-and-conversions/) of the
@@ -112,7 +112,7 @@ class MatomoAction {
     String? path,
     String? action,
     EventInfo? eventInfo,
-    String? screenId,
+    String? pvId,
     int? goalId,
     String? orderId,
     List<TrackingOrderItem>? trackingOrderItems,
@@ -137,7 +137,7 @@ class MatomoAction {
         path: path ?? this.path,
         action: action ?? this.action,
         eventInfo: eventInfo ?? this.eventInfo,
-        screenId: screenId ?? this.screenId,
+        pvId: pvId ?? this.pvId,
         goalId: goalId ?? this.goalId,
         orderId: orderId ?? this.orderId,
         trackingOrderItems: trackingOrderItems ?? this.trackingOrderItems,
@@ -162,7 +162,7 @@ class MatomoAction {
   Map<String, String> toMap(MatomoTracker tracker) {
     final id = tracker.visitor.id;
     final uid = tracker.visitor.uid;
-    final pvId = screenId;
+    final pvId = this.pvId;
     final actionName = action;
     final camp = campaign;
     final campKeyword = camp?.keyword;
@@ -187,6 +187,10 @@ class MatomoAction {
     final ecTx = taxAmount;
     final ecSh = shippingCost;
     final ecDt = discountAmount;
+    final search = searchKeyword;
+    final searchCat = searchCategory;
+    final searchCount = this.searchCount;
+    final link = this.link;
     final ua = tracker.userAgent;
     final dims = dimensions;
     final locale = PlatformDispatcher.instance.locale;
@@ -233,7 +237,6 @@ class MatomoAction {
       if (ua != null) 'ua': ua,
       'lang': locale.toString(),
       if (country != null && tracker.authToken != null) 'country': country,
-
       if (uid != null) 'uid': uid,
 
       // Optional Action info (measure Page view, Outlink, Download, Site search)
@@ -252,12 +255,10 @@ class MatomoAction {
       if (ecTx != null) 'ec_tx': ecTx.toString(),
       if (ecSh != null) 'ec_sh': ecSh.toString(),
       if (ecDt != null) 'ec_dt': ecDt.toString(),
-
-      if (searchKeyword != null) 'search': searchKeyword!,
-      if (searchCategory != null) 'search_cat': searchCategory!,
-      if (searchCount != null) 'search_count': searchCount!.toString(),
-
-      if (link != null) 'link': link!,
+      if (search != null) 'search': search,
+      if (searchCat != null) 'search_cat': searchCat,
+      if (searchCount != null) 'search_count': searchCount.toString(),
+      if (link != null) 'link': link,
 
       // Other parameters (require authentication via `token_auth`)
       'cdt': _date.toIso8601String(),

--- a/lib/src/persistent_queue.dart
+++ b/lib/src/persistent_queue.dart
@@ -26,7 +26,11 @@ class PersistentQueue extends DelegatingQueue<Map<String, String>> {
   @visibleForTesting
   static List<Map<String, String>> decode(String? actionsData) {
     if (actionsData != null) {
-      return (json.decode(actionsData) as List)
+      final actions = jsonDecode(actionsData);
+      if (actions is! List) {
+        throw FormatException('Expected a list of actions, but got: $actions');
+      }
+      return actions
           .cast<Map<String, dynamic>>()
           .map<Map<String, String>>((element) => element.cast())
           .toList();

--- a/lib/src/traceable_widget_mixin.dart
+++ b/lib/src/traceable_widget_mixin.dart
@@ -4,7 +4,7 @@ import 'package:matomo_tracker/utils/random_alpha_numeric.dart';
 
 final matomoObserver = RouteObserver<ModalRoute<void>>();
 
-/// Register a [MatomoTracker.trackScreenWithName] on this widget.
+/// Register a [MatomoTracker.trackPageViewWithName] on this widget.
 @optionalTypeArgs
 mixin TraceableClientMixin<T extends StatefulWidget> on State<T>
     implements RouteAware {
@@ -22,7 +22,7 @@ mixin TraceableClientMixin<T extends StatefulWidget> on State<T>
   /// The default implementation will generate one on widget creation
   /// (recommended).
   ///
-  /// For more information see `pvId` in [MatomoTracker.trackScreenWithName] and
+  /// For more information see `pvId` in [MatomoTracker.trackPageViewWithName] and
   /// [MatomoTracker.attachLastScreenInfo].
   /// {@endtemplate}
   @protected
@@ -92,7 +92,11 @@ mixin TraceableClientMixin<T extends StatefulWidget> on State<T>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    matomoObserver.subscribe(this, ModalRoute.of(context)!);
+
+    final route = ModalRoute.of(context);
+    if (route != null) {
+      matomoObserver.subscribe(this, route);
+    }
   }
 
   @override
@@ -119,7 +123,7 @@ mixin TraceableClientMixin<T extends StatefulWidget> on State<T>
   void didPushNext() {}
 
   void _track() {
-    tracker.trackScreenWithName(
+    tracker.trackPageViewWithName(
       actionName: actionName,
       pvId: pvId,
       path: path,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,8 @@ dependencies:
   uuid: ^3.0.7
 
 dev_dependencies:
-  fd_lints: ^1.1.1
+  custom_lint: ^0.4.0
+  fd_lints: ^2.0.0
   flutter_test:
     sdk: flutter
   meta: ^1.9.1

--- a/test/ressources/mock/data.dart
+++ b/test/ressources/mock/data.dart
@@ -45,8 +45,8 @@ const matomoGoalId = 1;
 const matomoLink = 'link';
 const matomoOrderId = 'orderId';
 const matomoRevenue = 1.0;
-const matomoScreenId = '123456'; // 6 characters
-const matomoWrongScreenId = '123';
+const matomoPvId = '123456'; // 6 characters
+const matomoWrongPvId = '123';
 const matomoSearchCategory = 'searchCategory';
 const matomoSearchCount = 1;
 const matomoSearchKeyword = 'searchKeyword';
@@ -139,7 +139,7 @@ final matomoTrackerLocalFirstVisist = DateTime.fromMillisecondsSinceEpoch(
   1640979000000,
   isUtc: true,
 );
-const matomoTrackerCurrentScreenId = '123456'; // 6 characters
+const matomoTrackerCurrentPvId = '123456'; // 6 characters
 
 // DeviceInfoPlugin
 const webBrowserUserAgent = 'webBrowserUserAgent';

--- a/test/src/matomo_action_test.dart
+++ b/test/src/matomo_action_test.dart
@@ -44,7 +44,7 @@ void main() {
       link: matomoLink,
       orderId: matomoOrderId,
       revenue: matomoRevenue,
-      screenId: matomoScreenId,
+      pvId: matomoPvId,
       searchCategory: matomoSearchCategory,
       searchCount: matomoSearchCount,
       searchKeyword: matomoSearchKeyword,
@@ -80,7 +80,7 @@ void main() {
     expect(matomoAction.link, matomoLink);
     expect(matomoAction.orderId, matomoOrderId);
     expect(matomoAction.revenue, matomoRevenue);
-    expect(matomoAction.screenId, matomoScreenId);
+    expect(matomoAction.pvId, matomoPvId);
     expect(matomoAction.searchCategory, matomoSearchCategory);
     expect(matomoAction.searchCount, matomoSearchCount);
     expect(matomoAction.searchKeyword, matomoSearchKeyword);
@@ -125,14 +125,14 @@ void main() {
       test(
         'it should throw AssertionError if screen id is not 6 characters',
         () {
-          MatomoAction getMatomoActionWithWrongScreenId() {
+          MatomoAction getMatomoActionWithWrongPvId() {
             return MatomoAction(
-              screenId: matomoWrongScreenId,
+              pvId: matomoWrongPvId,
             );
           }
 
           expect(
-            getMatomoActionWithWrongScreenId,
+            getMatomoActionWithWrongPvId,
             throwsAssertionError,
           );
         },
@@ -291,7 +291,7 @@ void main() {
         expect(matomoAction.link, unchangedCopy.link);
         expect(matomoAction.orderId, unchangedCopy.orderId);
         expect(matomoAction.revenue, unchangedCopy.revenue);
-        expect(matomoAction.screenId, unchangedCopy.screenId);
+        expect(matomoAction.pvId, unchangedCopy.pvId);
         expect(matomoAction.searchCategory, unchangedCopy.searchCategory);
         expect(matomoAction.searchCount, unchangedCopy.searchCount);
         expect(matomoAction.searchKeyword, unchangedCopy.searchKeyword);
@@ -367,7 +367,7 @@ void main() {
         expect(matomoAction.link, changedCopy.link);
         expect(matomoAction.orderId, changedCopy.orderId);
         expect(matomoAction.revenue, changedCopy.revenue);
-        expect(matomoAction.screenId, changedCopy.screenId);
+        expect(matomoAction.pvId, changedCopy.pvId);
         expect(matomoAction.searchCategory, changedCopy.searchCategory);
         expect(matomoAction.searchCount, changedCopy.searchCount);
         expect(matomoAction.searchKeyword, changedCopy.searchKeyword);

--- a/test/src/matomo_test.dart
+++ b/test/src/matomo_test.dart
@@ -160,36 +160,36 @@ void main() {
 
   group('tracking', () {
     testTracking(
-      'it should be able to trackScreen',
+      'it should be able to trackPageView',
       (tracker) {
         when(() => mockBuildContext.widget).thenReturn(matomoTrackerMockWidget);
 
-        tracker.trackScreen(context: mockBuildContext);
+        tracker.trackPageView(context: mockBuildContext);
       },
     );
 
-    group('trackScreenWithName', () {
+    group('trackPageViewWithName', () {
       uninitializedTest(
         (tracker) async {
-          tracker.trackScreenWithName(
+          tracker.trackPageViewWithName(
             actionName: matomoTrackerMockWidget.toStringShort(),
           );
         },
       );
 
-      testTracking('it should be able to trackScreenWithName', (tracker) {
-        tracker.trackScreenWithName(
+      testTracking('it should be able to trackPageViewWithName', (tracker) {
+        tracker.trackPageViewWithName(
           actionName: matomoTrackerMockWidget.toStringShort(),
         );
       });
 
       test(
-        'should throw ArgumentError if currentScreenId lenght != 6 ',
+        'should throw ArgumentError if currentPvId lenght != 6 ',
         () async {
           final matomoTracker = await getInitializedMatomoTracker();
 
           await expectLater(
-            () => matomoTracker.trackScreenWithName(
+            () => matomoTracker.trackPageViewWithName(
               actionName: matomoTrackerMockWidget.toStringShort(),
               pvId: '',
             ),


### PR DESCRIPTION
As suggested by @EPNW-Eric in his comment (https://github.com/Floating-Dartists/matomo-tracker/pull/109#issue-1742457658), I've renamed the `trackScreen` and `trackScreenWithName` to `trackPageView` and `trackPageViewWithName`. The parameter `screenId` was also renamed to `pvId`.

I've also updated the dev_dependency `fd_lints` to use the latest v2.0.0 with its new custom rules and made the refactor accordingly.