### PR TITLE
feat: fixed README and bumped dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ await MatomoTracker.instance.initialize(
 ```
 Note that this Visitor ID should not be confused with the User ID which is explained below!
 
+Then, for `TraceableClientMixin` and `TraceableWidget` to work, you will have to add `matomoObserver` to your navigatorObservers:
+
+```dart
+MaterialApp(
+    // ...
+    navigatorObservers: [
+        matomoObserver,
+    ],
+);
+```
+
 To track views simply add `TraceableClientMixin` on your `State`:
 
 ```dart
@@ -229,7 +240,7 @@ await MatomoTracker.instance.initialize(
 MaterialApp(
     // ...
     navigatorObservers: [
-        MatomoTracker.matomoObserver,
+        matomoObserver,
     ],
 );
 ```

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -39,7 +39,7 @@ android {
         applicationId "org.matomo_tracker.example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 19
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,20 +16,20 @@ environment:
 dependencies:
   clock: ^1.1.1
   collection: ^1.17.1
-  device_info_plus: ^9.0.2
+  device_info_plus: ^9.0.3
   flutter:
     sdk: flutter
-  http: ^1.0.0
-  package_info_plus: ^4.0.2
-  shared_preferences: ^2.1.1
+  http: ^1.1.0
+  package_info_plus: ^4.1.0
+  shared_preferences: ^2.2.0
   uuid: ^3.0.7
 
 dev_dependencies:
   custom_lint: ">=0.4.0 <0.6.0"
-  fd_lints: ^2.0.0
+  fd_lints: ^2.1.0
   flutter_test:
     sdk: flutter
   meta: ^1.9.1
-  mocktail: ">=0.3.0 <2.0.0"
+  mocktail: ^1.0.0
 
 flutter: null


### PR DESCRIPTION
Fix #117 

* Fixed migration documentation in `README.md` and added a step in the "Getting Started" section to include `matomoObserver` to the `navigatorObservers`
* Bumped dependencies versions