### PR TITLE
Feat: Change url on the fly

### DIFF
--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -71,6 +71,8 @@ class MatomoTracker {
   String? _url;
 
   void setUrl(String newUrl) {
+    _initializationCheck();
+
     _url = newUrl;
     _dispatcher = _dispatcher.copyWith(baseUrl: newUrl);
   }

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -45,6 +45,9 @@ class MatomoTracker {
 
   late final PlatformInfo _platformInfo;
 
+  @visibleForTesting
+  MatomoDispatcher get dispatcher => _dispatcher;
+
   late MatomoDispatcher _dispatcher;
 
   static final instance = MatomoTracker._internal();
@@ -61,6 +64,8 @@ class MatomoTracker {
   /// Should not be confused with the `url` tracking parameter
   /// which is constructed by combining [contentBase] with a `path`
   /// (e.g. in [trackPageViewWithName]).
+  ///
+  /// You can use [setUrl] to change this value after initialization.
   String get url {
     if (_url case final url?) {
       return url;
@@ -70,6 +75,10 @@ class MatomoTracker {
 
   String? _url;
 
+  /// Sets the url of the Matomo endpoint and updates the dispatcher.
+  ///
+  /// Note that this will change the url used by the request that are still
+  /// in the queue.
   void setUrl(String newUrl) {
     _initializationCheck();
 

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -61,7 +61,20 @@ class MatomoTracker {
   /// Should not be confused with the `url` tracking parameter
   /// which is constructed by combining [contentBase] with a `path`
   /// (e.g. in [trackPageViewWithName]).
-  late final String url;
+  String get url {
+    if (_url case final url?) {
+      return url;
+    }
+    throw const UninitializedMatomoInstanceException();
+  }
+
+  String? _url;
+
+  void setUrl(String newUrl) {
+    _url = newUrl;
+    _dispatcher = _dispatcher.copyWith(baseUrl: newUrl);
+  }
+
   late final Session session;
 
   Visitor get visitor => _visitor;
@@ -223,7 +236,7 @@ class MatomoTracker {
     log.setLogging(level: verbosityLevel);
 
     this.siteId = siteId;
-    this.url = url;
+    _url = url;
     this.customHeaders = customHeaders;
     _pingInterval = pingInterval;
     _lock = sync.Lock();

--- a/lib/src/matomo_dispatcher.dart
+++ b/lib/src/matomo_dispatcher.dart
@@ -78,4 +78,20 @@ class MatomoDispatcher {
 
     return baseUri.replace(queryParameters: queryParameters);
   }
+
+  MatomoDispatcher copyWith({
+    String? baseUrl,
+    String? tokenAuth,
+    String? userAgent,
+    Logger? log,
+    http.Client? httpClient,
+  }) {
+    return MatomoDispatcher(
+      baseUrl: baseUrl ?? baseUri.toString(),
+      tokenAuth: tokenAuth ?? this.tokenAuth,
+      userAgent: userAgent ?? this.userAgent,
+      log: log ?? this.log,
+      httpClient: httpClient ?? this.httpClient,
+    );
+  }
 }

--- a/test/ressources/mock/data.dart
+++ b/test/ressources/mock/data.dart
@@ -191,7 +191,7 @@ const wantedContentMap = <String, String>{
 const wantedContentMapFull = <String, String>{
   'c_n': matomoContentName,
   'c_p': matomoContentPiece,
-  'c_t': matomoContentTarget
+  'c_t': matomoContentTarget,
 };
 
 // PerformanceInfo

--- a/test/src/dispatch_settings_test.dart
+++ b/test/src/dispatch_settings_test.dart
@@ -127,7 +127,7 @@ void main() {
           // will filter out recent
           DispatchSettings.whereUserId(_uid2),
           // will filter out old
-          DispatchSettings.whereNotOlderThanADay
+          DispatchSettings.whereNotOlderThanADay,
         ],
       );
       final after = [old, recent]..retainWhere(chained);

--- a/test/src/matomo_dispatcher_test.dart
+++ b/test/src/matomo_dispatcher_test.dart
@@ -207,4 +207,44 @@ void main() {
       ),
     );
   });
+
+  group('copyWith', () {
+    test('should copy with new url', () {
+      const newUrl = 'https://test.com';
+
+      final initialDispatcher = MatomoDispatcher(
+        baseUrl: matomoDispatcherBaseUrl,
+        userAgent: matomoTrackerUserAgent,
+        tokenAuth: matomoDispatcherToken,
+        httpClient: mockHttpClient,
+        log: mockLogger,
+      );
+
+      final newDispatcher = initialDispatcher.copyWith(baseUrl: newUrl);
+
+      expect(newDispatcher.baseUri.toString(), newUrl);
+      expect(newDispatcher.userAgent, matomoTrackerUserAgent);
+      expect(newDispatcher.tokenAuth, matomoDispatcherToken);
+      expect(newDispatcher.httpClient, mockHttpClient);
+      expect(newDispatcher.log, mockLogger);
+    });
+
+    test('should do nothing', () {
+      final initialDispatcher = MatomoDispatcher(
+        baseUrl: matomoDispatcherBaseUrl,
+        userAgent: matomoTrackerUserAgent,
+        tokenAuth: matomoDispatcherToken,
+        httpClient: mockHttpClient,
+        log: mockLogger,
+      );
+
+      final newDispatcher = initialDispatcher.copyWith();
+
+      expect(newDispatcher.baseUri.toString(), matomoDispatcherBaseUrl);
+      expect(newDispatcher.userAgent, matomoTrackerUserAgent);
+      expect(newDispatcher.tokenAuth, matomoDispatcherToken);
+      expect(newDispatcher.httpClient, mockHttpClient);
+      expect(newDispatcher.log, mockLogger);
+    });
+  });
 }

--- a/test/src/matomo_test.dart
+++ b/test/src/matomo_test.dart
@@ -478,10 +478,8 @@ void main() {
 
   group('url getter', () {
     test('should throw if not initialized', () {
-      final tracker = MatomoTracker();
-
       expect(
-        () => tracker.url,
+        () => MatomoTracker().url,
         throwsA(isA<UninitializedMatomoInstanceException>()),
       );
     });
@@ -489,12 +487,20 @@ void main() {
 
   group('setUrl', () {
     test('should throw if not initialized', () {
-      final tracker = MatomoTracker();
-
       expect(
-        () => tracker.setUrl(''),
+        () => MatomoTracker().setUrl(''),
         throwsA(isA<UninitializedMatomoInstanceException>()),
       );
+    });
+
+    test('should set the new url and dispatcher', () async {
+      const newUrl = 'https://test.com';
+      final tracker = await getInitializedMatomoTracker();
+
+      tracker.setUrl(newUrl);
+
+      expect(tracker.url, newUrl);
+      expect(tracker.dispatcher.baseUri.toString(), newUrl);
     });
   });
 }

--- a/test/src/matomo_test.dart
+++ b/test/src/matomo_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:matomo_tracker/src/content.dart';
 import 'package:matomo_tracker/src/event_info.dart';
+import 'package:matomo_tracker/src/exceptions.dart';
 import 'package:matomo_tracker/src/matomo.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -473,5 +474,27 @@ void main() {
         );
       },
     );
+  });
+
+  group('url getter', () {
+    test('should throw if not initialized', () {
+      final tracker = MatomoTracker();
+
+      expect(
+        () => tracker.url,
+        throwsA(isA<UninitializedMatomoInstanceException>()),
+      );
+    });
+  });
+
+  group('setUrl', () {
+    test('should throw if not initialized', () {
+      final tracker = MatomoTracker();
+
+      expect(
+        () => tracker.setUrl(''),
+        throwsA(isA<UninitializedMatomoInstanceException>()),
+      );
+    });
   });
 }

--- a/test/src/persistent_queue_test.dart
+++ b/test/src/persistent_queue_test.dart
@@ -25,7 +25,7 @@ const _nonEmptyJsonElementCount = 2;
 const _action = <String, String>{'action3': 'value3'};
 const _actions = [
   _action,
-  <String, String>{'action4': 'value4'}
+  <String, String>{'action4': 'value4'},
 ];
 
 void main() {


### PR DESCRIPTION
Fix #119 

This PR adds a method `setUrl` to the tracker that will update the url used inside the dispatcher. (I've also fixed some warnings from the analyzer)