### PR TITLE
132 contentbaseurl not working with hash sign

### DIFF
--- a/lib/src/matomo_action.dart
+++ b/lib/src/matomo_action.dart
@@ -167,17 +167,23 @@ class MatomoAction {
     final camp = campaign;
     final campKeyword = camp?.keyword;
     final localPath = path;
-    final uri = Uri.parse(
-      localPath != null
-          ? '${tracker.contentBase}${localPath.prefixWithSlash()}'
-          : tracker.contentBase,
-    );
-    final url = uri.replace(
-      queryParameters: {
-        if (camp != null) ...camp.toMap(),
-        ...uri.queryParameters,
-      },
-    ).toString();
+
+    final baseUrl = (localPath != null
+            ? '${tracker.contentBase.removeTrailingSlash()}${localPath.prefixWithSlash()}'
+            : tracker.contentBase)
+        .replaceHashtags();
+    final uri = Uri.parse(baseUrl);
+    final url = uri
+        .replace(
+          queryParameters: camp != null || uri.queryParameters.isNotEmpty
+              ? {
+                  if (camp != null) ...camp.toMap(),
+                  ...uri.queryParameters,
+                }
+              : null,
+        )
+        .toString()
+        .restoreHashtags();
     final idgoal = goalId;
     final aRevenue = revenue;
     final event = eventInfo;
@@ -271,4 +277,15 @@ class MatomoAction {
       if (dims != null) ...dims,
     };
   }
+}
+
+extension on String {
+  String removeTrailingSlash() {
+    if (endsWith('/')) return substring(0, length - 1);
+    return this;
+  }
+
+  static const _placeholder = 'HASHTAG_PLACEHOLDER';
+  String replaceHashtags() => replaceAll('/#/', '/$_placeholder/');
+  String restoreHashtags() => replaceAll('/$_placeholder/', '/#/');
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   meta: ^1.9.1
-  mocktail: ^1.0.1
+  mocktail: ^1.0.2
 
 flutter: null

--- a/test/src/matomo_action_test.dart
+++ b/test/src/matomo_action_test.dart
@@ -12,9 +12,12 @@ import '../ressources/mock/data.dart';
 import '../ressources/mock/mock.dart';
 
 void main() {
-  MatomoAction getCompleteMatomoAction() {
+  MatomoAction getCompleteMatomoAction({
+    String path = matomoActionPath,
+    bool withCampaign = true,
+  }) {
     return MatomoAction(
-      path: matomoActionPath,
+      path: path,
       action: matomoActionName,
       dimensions: matomoEventDimension,
       discountAmount: matomoDiscountAmount,
@@ -24,16 +27,18 @@ void main() {
         name: matomoEventName,
         value: matomoEventValue,
       ),
-      campaign: Campaign(
-        name: matomoCampaignName,
-        keyword: matomoCampaignKeyword,
-        source: matomoCampaignSource,
-        medium: matomoCampaignMedium,
-        content: matomoCampaignContent,
-        id: matomoCampaignId,
-        group: matomoCampaignGroup,
-        placement: matomoCampaignPlacement,
-      ),
+      campaign: withCampaign
+          ? Campaign(
+              name: matomoCampaignName,
+              keyword: matomoCampaignKeyword,
+              source: matomoCampaignSource,
+              medium: matomoCampaignMedium,
+              content: matomoCampaignContent,
+              id: matomoCampaignId,
+              group: matomoCampaignGroup,
+              placement: matomoCampaignPlacement,
+            )
+          : null,
       content: Content(
         name: matomoContentName,
         piece: matomoContentPiece,
@@ -245,6 +250,25 @@ void main() {
         wantedEvent.remove('rand');
 
         expect(mapEquals(wantedEvent, eventMap), isTrue);
+      });
+    });
+
+    test('Issue #132: bad url encoding', () {
+      final fixedDate = DateTime(2022).toUtc();
+      const contentBase = 'https://app.articlett.schule/#/';
+      const localPath = 'sherlock';
+      const expectedUrl = "https%3A%2F%2Fapp.articlett.schule%2F%23%2Fsherlock";
+
+      when(() => mockMatomoTracker.contentBase).thenReturn(contentBase);
+
+      withClock(Clock.fixed(fixedDate), () {
+        final matomoAction = getCompleteMatomoAction(
+          path: localPath,
+          withCampaign: false,
+        );
+        final eventMap = matomoAction.toMap(mockMatomoTracker);
+
+        expect(eventMap['url'], expectedUrl);
       });
     });
   });

--- a/test/src/matomo_action_test.dart
+++ b/test/src/matomo_action_test.dart
@@ -267,8 +267,7 @@ void main() {
           withCampaign: false,
         );
         final eventMap = matomoAction.toMap(mockMatomoTracker);
-
-        expect(eventMap['url'], expectedUrl);
+        expect(Uri.encodeQueryComponent(eventMap['url'] ?? ''), expectedUrl);
       });
     });
   });


### PR DESCRIPTION
Fix #132 

`Uri.parse` consider the `#` as a fragment marker, making it unreliable for urls containing `#`, as a workaround I'm replacing this character with a placeholder to manipulate the Uri correctly before restoring it when it's converted back to a `String`. (I'm open to a better way to do this if anybody has an idea)

I've added a non regression test to verify the fix under `matomo_action_test.dart`.