### PR TITLE
Allow uuid 5.x

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   http: ^1.1.0
   package_info_plus: ">=4.2.0 <6.0.0"
   shared_preferences: ^2.2.2
-  uuid: ^4.1.0
+  uuid: ">=4.1.0 <6.0.0"
 
 dev_dependencies:
   custom_lint: ^0.5.4


### PR DESCRIPTION
The `uuid` package for 5.x changed the constructor parameters. Since these are not used in this package, it's enough to update `pubspec.yaml` to allow `uuid` version 4.x and 5.x.