### PR TITLE
Add grandTotal/revenue to trackCartUpdate

### DIFF
--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -725,7 +725,7 @@ class MatomoTracker {
         taxAmount: taxAmount,
         shippingCost: shippingCost,
         discountAmount: discountAmount,
-        revenue: grandTotal
+        revenue: grandTotal,
         pvId: _inferPvId(pvId),
         path: _inferPath(path),
         campaign: campaign,

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -706,6 +706,7 @@ class MatomoTracker {
     num? taxAmount,
     num? shippingCost,
     num? discountAmount,
+    num? grandTotal,
     String? pvId,
     String? path,
     Campaign? campaign,
@@ -724,6 +725,7 @@ class MatomoTracker {
         taxAmount: taxAmount,
         shippingCost: shippingCost,
         discountAmount: discountAmount,
+        revenue: grandTotal
         pvId: _inferPvId(pvId),
         path: _inferPath(path),
         campaign: campaign,

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -706,7 +706,7 @@ class MatomoTracker {
     num? taxAmount,
     num? shippingCost,
     num? discountAmount,
-    num? grandTotal,
+    double? grandTotal,
     String? pvId,
     String? path,
     Campaign? campaign,


### PR DESCRIPTION
According to Matomo documentation we need to track the total revenue with trackEcommerceCartUpdate ([Docs](https://matomo.org/faq/reports/advanced-manually-tracking-ecommerce-actions-in-matomo/#example-product-cart-update)).

I also checked the source code for Matomo's js tracker and found that the beforehand mentioned functionality results in revenue parameter being set ([here](https://github.com/matomo-org/matomo/blob/5.x-dev/js/piwik.js#L4205) and [here](https://github.com/matomo-org/matomo/blob/5.x-dev/js/piwik.js#L4140)).

The following code results in a empty revenue cart in Matomo:

```dart
MatomoTracker.instance.trackCartUpdate(
    trackingOrderItems: cartState.items.values
        .map((e) => TrackingOrderItem(
            sku: e.uuid,
            name: e.offeringItem.item.getName(),
            price: e.offeringItem.price / 100.0,
            quantity: e.amount))
        .toList(),
    grandTotal: total);
```
Matomo Screenshot:
![Screenshot 2024-02-20 at 16 35 41](https://github.com/Floating-Dartists/matomo-tracker/assets/37074703/3c650117-3216-4c02-80d2-dd19effb9efd)