### PR TITLE
Fix country code case

### DIFF
--- a/lib/src/matomo_action.dart
+++ b/lib/src/matomo_action.dart
@@ -200,7 +200,7 @@ class MatomoAction {
     final ua = tracker.userAgent;
     final dims = dimensions;
     final locale = PlatformDispatcher.instance.locale;
-    final country = locale.countryCode;
+    final country = locale.countryCode?.toLowerCase();
     final nV = newVisit;
     final p = ping;
     final cont = content;


### PR DESCRIPTION
Convert to lowercase since upper case codes lead to missing flag symbols in the backend.