### PR TITLE
Add iOS machine name to user agent

### DIFF
--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -385,8 +385,9 @@ class MatomoTracker {
         final systemName = iosInfo.systemName;
         final version = iosInfo.systemVersion;
         final model = iosInfo.model;
+        final machine = iosInfo.utsname.machine;
 
-        return '$systemName $version, $model';
+        return '$systemName $version, $model $machine';
       } else if (_platformInfo.isWindows) {
         final windowsInfo = await effectiveDeviceInfo.windowsInfo;
         final releaseId = windowsInfo.releaseId;

--- a/test/ressources/mock/data.dart
+++ b/test/ressources/mock/data.dart
@@ -150,6 +150,7 @@ const androidModel = 'androidModel';
 const iosSystemName = 'iosSystemName';
 const iosSystemVersion = 'iosSystemVersion';
 const iosModel = 'iosModel';
+const iosMachine = 'iosMachine';
 const windowsReleaseId = 'windowsReleaseId';
 const windowsBuildNumber = 1;
 const macOsModel = 'macOsModel';

--- a/test/ressources/mock/mock.dart
+++ b/test/ressources/mock/mock.dart
@@ -42,6 +42,8 @@ class MockAndroidBuildVersion extends Mock implements AndroidBuildVersion {}
 
 class MockIosDeviceInfo extends Mock implements IosDeviceInfo {}
 
+class MockIosDeviceUtsname extends Mock implements IosUtsname {}
+
 class MockWindowsDeviceInfo extends Mock implements WindowsDeviceInfo {}
 
 class MockMacOsDeviceInfo extends Mock implements MacOsDeviceInfo {}
@@ -76,6 +78,7 @@ final mockWebBrowserInfo = MockWebBrowserInfo();
 final mockAndroidDeviceInfo = MockAndroidDeviceInfo();
 final mockAndroidBuildVersion = MockAndroidBuildVersion();
 final mockIosDeviceInfo = MockIosDeviceInfo();
+final mockIosUtsname = MockIosDeviceUtsname();
 final mockWindowsDeviceInfo = MockWindowsDeviceInfo();
 final mockMacOsDeviceInfo = MockMacOsDeviceInfo();
 final mockLinuxDeviceInfo = MockLinuxDeviceInfo();

--- a/test/src/matomo_test.dart
+++ b/test/src/matomo_test.dart
@@ -303,6 +303,8 @@ void main() {
       when(() => mockIosDeviceInfo.systemName).thenReturn(iosSystemName);
       when(() => mockIosDeviceInfo.systemVersion).thenReturn(iosSystemVersion);
       when(() => mockIosDeviceInfo.model).thenReturn(iosModel);
+      when(() => mockIosDeviceInfo.utsname).thenReturn(mockIosUtsname);
+      when(() => mockIosUtsname.machine).thenReturn(iosMachine);
 
       // Windows
       when(() => mockDeviceInfoPlugin.windowsInfo)
@@ -373,7 +375,7 @@ void main() {
 
       expect(
         userAgent,
-        '$iosSystemName $iosSystemVersion, $iosModel',
+        '$iosSystemName $iosSystemVersion, $iosModel $iosMachine',
       );
     });
 


### PR DESCRIPTION
This allows matomo to figure out the exact iOS device (for example "iPhone 14 Pro Max") instead of just "iPhone".