### PR TITLE
chore: bump dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,18 +16,18 @@ environment:
 dependencies:
   clock: ^1.1.1
   collection: ^1.18.0
-  device_info_plus: ">=9.1.0 <11.0.0"
+  device_info_plus: ^11.0.0
   flutter:
     sdk: flutter
-  http: ^1.2.1
-  package_info_plus: ">=4.2.0 <9.0.0"
-  shared_preferences: ^2.2.3
-  uuid: ">=4.1.0 <6.0.0"
+  http: ^1.2.2
+  package_info_plus: ^8.0.3
+  shared_preferences: ^2.3.2
+  uuid: ^4.5.1
 
 dev_dependencies:
   custom_lint: ">=0.5.4 <0.7.0"
-  fd_lints: ^2.2.1
+  fd_lints: ^2.3.0
   flutter_test:
     sdk: flutter
   meta: ^1.12.0
-  mocktail: ^1.0.3
+  mocktail: ^1.0.4


### PR DESCRIPTION
Fix #176 

* device_info_plus: 11.0.0
* http: 1.2.2
* package_info_plus: 8.0.3
* shared_preferences: 2.3.2
* uuid: 4.5.1