### PR TITLE
Change dispatchActions during initialization to unawaited

### DIFF
--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -337,7 +337,7 @@ class MatomoTracker {
     }
 
     if (queue.isNotEmpty) {
-      await dispatchActions();
+      unawaited(dispatchActions());
     }
   }
 


### PR DESCRIPTION
We recently integrated this package. During a high volume usage time of our app over the weekend, our Matomo server was at full capacity (100% CPU) and taking multiple seconds to return from the batch call. Our app load was blocked waiting for the return from the server during dispatchActions at initialization (persistent queue). We are updating our server to handle the increased load, but do not want the chance our app is blocked from loading. This is a simple change to make that call unawaited.
