### PR TITLE
fix: flutter 3.29 conditional import

### DIFF
--- a/lib/src/platform_info/platform_info.dart
+++ b/lib/src/platform_info/platform_info.dart
@@ -2,7 +2,7 @@ import 'package:flutter/cupertino.dart';
 
 import 'package:matomo_tracker/src/platform_info/platform_info_interface.dart';
 import 'package:matomo_tracker/src/platform_info/platform_info_io.dart'
-    if (dart.library.html) 'package:matomo_tracker/src/platform_info/platform_info_web.dart';
+    if (dart.library.js_interop) 'package:matomo_tracker/src/platform_info/platform_info_web.dart';
 
 class PlatformInfo extends PlatformInfoInterface {
   PlatformInfo._internal();


### PR DESCRIPTION
conditional import has to be dart.library.js_interop instead of dart.library.html. Refer to https://dart.dev/interop/js-interop/package-web#conditional-imports