### PR TITLE
Issue #189: bugfix: reset/initialize visitor when setCookieless is called

### DIFF
--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -132,25 +132,36 @@ class MatomoTracker {
   late final Size screenResolution;
 
   bool _initialized = false;
+
   bool get initialized => _initialized;
 
   bool _optOut = false;
+
   bool get optOut => _optOut;
+
   Future<void> setOptOut({required bool optOut}) async {
     _optOut = optOut;
     await _localStorage.setOptOut(optOut: optOut);
   }
 
   bool _cookieless = false;
+
   bool get cookieless => _cookieless;
 
-  void setCookieless({
+  Future<void> setCookieless({
     required bool cookieless,
     LocalStorage? localStorage,
-  }) {
+  }) async {
     if (_cookieless == cookieless) return;
     _cookieless = cookieless;
     _setLocalStorage(localStorage);
+
+    if (cookieless) {
+      _visitor = const Visitor();
+    } else {
+      final visitorId = await _getVisitorId();
+      _visitor = Visitor(id: visitorId);
+    }
   }
 
   void _setLocalStorage(LocalStorage? localStorage) {

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -132,11 +132,9 @@ class MatomoTracker {
   late final Size screenResolution;
 
   bool _initialized = false;
-
   bool get initialized => _initialized;
 
   bool _optOut = false;
-
   bool get optOut => _optOut;
 
   Future<void> setOptOut({required bool optOut}) async {
@@ -145,7 +143,6 @@ class MatomoTracker {
   }
 
   bool _cookieless = false;
-
   bool get cookieless => _cookieless;
 
   Future<void> setCookieless({

--- a/test/ressources/utils/get_initialized_mamoto_tracker.dart
+++ b/test/ressources/utils/get_initialized_mamoto_tracker.dart
@@ -17,6 +17,7 @@ Future<MatomoTracker> getInitializedMatomoTracker({
   String? tokenAuth,
   PlatformInfo? platformInfo,
   bool shouldForceCreation = true,
+  bool cookieless = false,
 }) async {
   final matomoTracker =
       shouldForceCreation ? MatomoTracker() : MatomoTracker.instance;
@@ -34,6 +35,7 @@ Future<MatomoTracker> getInitializedMatomoTracker({
     contentBaseUrl: contentBaseUrl,
     tokenAuth: tokenAuth,
     platformInfo: platformInfo,
+    cookieless: cookieless,
   );
 
   return matomoTracker;

--- a/test/ressources/utils/matomo_tracker_setup.dart
+++ b/test/ressources/utils/matomo_tracker_setup.dart
@@ -4,10 +4,10 @@ import 'package:mocktail/mocktail.dart';
 import '../mock/data.dart';
 import '../mock/mock.dart';
 
-void matomoTrackerSetup({String? visitorId}) {
+void matomoTrackerSetup() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  when(mockLocalStorage.getVisitorId).thenAnswer((_) async => visitorId);
+  when(mockLocalStorage.getVisitorId).thenAnswer((_) async => null);
   when(() => mockLocalStorage.setVisitorId(any()))
       .thenAnswer((_) => Future.value());
   when(mockLocalStorage.getOptOut).thenAnswer((_) async => false);

--- a/test/ressources/utils/matomo_tracker_setup.dart
+++ b/test/ressources/utils/matomo_tracker_setup.dart
@@ -4,16 +4,15 @@ import 'package:mocktail/mocktail.dart';
 import '../mock/data.dart';
 import '../mock/mock.dart';
 
-void matomoTrackerSetup() {
+void matomoTrackerSetup({String? visitorId}) {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  when(mockLocalStorage.getVisitorId).thenAnswer((_) async => null);
+  when(mockLocalStorage.getVisitorId).thenAnswer((_) async => visitorId);
   when(() => mockLocalStorage.setVisitorId(any()))
       .thenAnswer((_) => Future.value());
   when(mockLocalStorage.getOptOut).thenAnswer((_) async => false);
   when(() => mockLocalStorage.setOptOut(optOut: any(named: 'optOut')))
       .thenAnswer((_) => Future.value());
   when(mockLocalStorage.clear).thenAnswer((_) => Future.value());
-  when(() => mockPackageInfo.packageName).thenReturn(matomoTrackerPackageName);
   when(() => mockPackageInfo.packageName).thenReturn(matomoTrackerPackageName);
 }

--- a/test/src/cookieless_test.dart
+++ b/test/src/cookieless_test.dart
@@ -1,14 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 
+import '../ressources/mock/data.dart';
 import '../ressources/mock/mock.dart';
 import '../ressources/utils/get_initialized_mamoto_tracker.dart';
 import '../ressources/utils/matomo_tracker_setup.dart';
 
 void main() {
   group('Cookieless', () {
-    setUp(() {
-      matomoTrackerSetup(visitorId: 'someRandomVisitorId');
-    });
+    setUp(matomoTrackerSetup);
 
     test('activate cookieless clears VisitorId', () async {
       // cookieless is off by default
@@ -20,6 +20,9 @@ void main() {
     });
 
     test('deactivate cookieless initializes VisitorId', () async {
+      when(mockLocalStorage.getVisitorId)
+          .thenAnswer((_) async => matomoTrackerVisitorId);
+
       final tracker = await getInitializedMatomoTracker(
         cookieless: true,
       );

--- a/test/src/cookieless_test.dart
+++ b/test/src/cookieless_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../ressources/mock/mock.dart';
+import '../ressources/utils/get_initialized_mamoto_tracker.dart';
+import '../ressources/utils/matomo_tracker_setup.dart';
+
+void main() {
+  group('Cookieless', () {
+    setUp(() {
+      matomoTrackerSetup(visitorId: 'someRandomVisitorId');
+    });
+
+    test('activate cookieless clears VisitorId', () async {
+      // cookieless is off by default
+      final tracker = await getInitializedMatomoTracker();
+      expect(tracker.visitor.id, isNotNull);
+
+      await tracker.setCookieless(cookieless: true);
+      expect(tracker.visitor.id, isNull);
+    });
+
+    test('deactivate cookieless initializes VisitorId', () async {
+      final tracker = await getInitializedMatomoTracker(
+        cookieless: true,
+      );
+      expect(tracker.visitor.id, isNull);
+
+      await tracker.setCookieless(
+        cookieless: false,
+        localStorage: mockLocalStorage,
+      );
+      expect(tracker.visitor.id, isNotNull);
+    });
+  });
+}

--- a/test/src/cookieless_test.dart
+++ b/test/src/cookieless_test.dart
@@ -12,7 +12,9 @@ void main() {
 
     test('activate cookieless clears VisitorId', () async {
       // cookieless is off by default
-      final tracker = await getInitializedMatomoTracker();
+      final tracker = await getInitializedMatomoTracker(
+        visitorId: matomoTrackerVisitorId,
+      );
       expect(tracker.visitor.id, isNotNull);
 
       await tracker.setCookieless(cookieless: true);


### PR DESCRIPTION
I created a PR for #189. Let me know if there's anything I should adapt.