### PR TITLE
Add support for custom user language

### DIFF
--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -102,15 +102,11 @@ class MatomoTracker {
   }
 
   /// The active locale (language & country code) for the current user.
-  /// This can be different from the system-reported default locale of the device.
-  Locale? _userLocale;
-  Locale? get userLocale => _userLocale;
-
-  /// Set userLocale to override the `lang` parameter sent to matomo.
-  // ignore: use_setters_to_change_properties
-  void setUserLocale(Locale locale) {
-    _userLocale = locale;
-  }
+  /// Set this to override the language reported the system-reported default locale of the device.
+  /// Attention: Changing the user locale might override visitor country if GeoIP is not enabled.
+  /// If you don't want this behavior, consider saving the user locale as a custom dimension:
+  /// https://matomo.org/guide/reporting-tools/custom-dimensions/
+  Locale? userLocale;
 
   /// Whether to attach `pvId` and `path` to `track...` calls automatically.
   ///

--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -101,6 +101,17 @@ class MatomoTracker {
     );
   }
 
+  /// The active locale (language & country code) for the current user.
+  /// This can be different from the system-reported default locale of the device.
+  Locale? _userLocale;
+  Locale? get userLocale => _userLocale;
+
+  /// Set userLocale to override the `lang` parameter sent to matomo.
+  // ignore: use_setters_to_change_properties
+  void setUserLocale(Locale locale) {
+    _userLocale = locale;
+  }
+
   /// Whether to attach `pvId` and `path` to `track...` calls automatically.
   ///
   /// There most actions can be associated with page views by setting a `pvId`
@@ -536,6 +547,7 @@ class MatomoTracker {
       path: path,
       campaign: campaign,
       dimensions: dimensions,
+      userLocale: userLocale,
       pvId: pvId ?? randomAlphaNumeric(6),
       performanceInfo: performanceInfo,
       newVisit: _inferNewVisit(newVisit),
@@ -580,6 +592,7 @@ class MatomoTracker {
         path: _inferPath(path),
         campaign: campaign,
         dimensions: dimensions,
+        userLocale: userLocale,
         newVisit: _inferNewVisit(newVisit),
       ),
     );
@@ -610,6 +623,7 @@ class MatomoTracker {
         path: _inferPath(path),
         campaign: campaign,
         dimensions: dimensions,
+        userLocale: userLocale,
         newVisit: _inferNewVisit(newVisit),
       ),
     );
@@ -650,6 +664,7 @@ class MatomoTracker {
         path: _inferPath(path),
         campaign: campaign,
         dimensions: dimensions,
+        userLocale: userLocale,
         newVisit: _inferNewVisit(newVisit),
       ),
     );
@@ -687,6 +702,7 @@ class MatomoTracker {
         path: _inferPath(path),
         campaign: campaign,
         dimensions: dimensions,
+        userLocale: userLocale,
         newVisit: _inferNewVisit(newVisit),
       ),
     );
@@ -731,6 +747,7 @@ class MatomoTracker {
         path: _inferPath(path),
         campaign: campaign,
         dimensions: dimensions,
+        userLocale: userLocale,
         newVisit: _inferNewVisit(newVisit),
       ),
     );
@@ -781,6 +798,7 @@ class MatomoTracker {
         path: _inferPath(path),
         campaign: campaign,
         dimensions: dimensions,
+        userLocale: userLocale,
         newVisit: _inferNewVisit(newVisit),
       ),
     );
@@ -815,6 +833,7 @@ class MatomoTracker {
         path: _inferPath(path),
         campaign: campaign,
         dimensions: dimensions,
+        userLocale: userLocale,
         newVisit: _inferNewVisit(newVisit),
       ),
     );
@@ -847,6 +866,7 @@ class MatomoTracker {
         path: _inferPath(path),
         campaign: campaign,
         dimensions: dimensions,
+        userLocale: userLocale,
         newVisit: _inferNewVisit(newVisit),
       ),
     );
@@ -885,6 +905,7 @@ class MatomoTracker {
         path: _inferPath(path),
         campaign: campaign,
         dimensions: dimensions,
+        userLocale: userLocale,
       ),
     );
   }

--- a/lib/src/matomo_action.dart
+++ b/lib/src/matomo_action.dart
@@ -26,6 +26,7 @@ class MatomoAction {
     this.link,
     this.campaign,
     this.dimensions,
+    this.userLocale,
     this.newVisit,
     this.ping,
     this.content,
@@ -99,6 +100,9 @@ class MatomoAction {
   // The dimensions associated with the action
   final Map<String, String>? dimensions;
 
+  // User defined locale
+  final Locale? userLocale;
+
   final bool? newVisit;
 
   final bool? ping;
@@ -127,6 +131,7 @@ class MatomoAction {
     String? link,
     Campaign? campaign,
     Map<String, String>? dimensions,
+    Locale? userLocale,
     bool? newVisit,
     bool? ping,
     Content? content,
@@ -152,6 +157,7 @@ class MatomoAction {
         link: link ?? this.link,
         campaign: campaign ?? this.campaign,
         dimensions: dimensions ?? this.dimensions,
+        userLocale: userLocale ?? this.userLocale,
         newVisit: newVisit ?? this.newVisit,
         ping: ping ?? this.ping,
         content: content ?? this.content,
@@ -179,7 +185,7 @@ class MatomoAction {
         )
         .toString()
         .restoreHashtags();
-    final locale = PlatformDispatcher.instance.locale;
+    final locale = userLocale ?? PlatformDispatcher.instance.locale;
     final country = locale.countryCode?.toLowerCase();
     final ping = this.ping ?? false;
 


### PR DESCRIPTION
Hi there

In one of our projects, the user can switch the language in the app itself, independently of the current system language.

For those scenarios, it would be nice if the language reported to matomo can be parametrized.

This PR adds a simple interface to override the language like so:

```
// Set active user language
MatomoTracker.instance.setUserLocale(context.locale);
```