### PR TITLE
feat: request body support for customization.

### DIFF
--- a/lib/src/matomo.dart
+++ b/lib/src/matomo.dart
@@ -251,6 +251,7 @@ class MatomoTracker {
     Map<String, String> customHeaders = const {},
     String? userAgent,
     bool attachLastScreenInfo = true,
+    MatomoSerializer? serializer,
   }) async {
     if (_initialized) {
       throw const AlreadyInitializedMatomoInstanceException();
@@ -309,6 +310,7 @@ class MatomoTracker {
       userAgent: this.userAgent,
       httpClient: httpClient,
       log: log,
+      serializer: serializer,
     );
 
     // Screen Resolution

--- a/lib/src/matomo_dispatcher.dart
+++ b/lib/src/matomo_dispatcher.dart
@@ -4,6 +4,15 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:matomo_tracker/src/logger/logger.dart';
 
+/// Will be invoked with the list of serialized actions and should return
+/// the final payload to be sent to Matomo.
+///
+/// The final result needs to adhere to the format of the body of [http.BaseClient._sendUnstreamed].
+/// - `String` for sending as JSON string
+/// - `Map<String, String>` for sending as form data
+/// - `List<int>` for sending as bytes
+typedef MatomoSerializer = dynamic Function(List<Map<String, String>> actions);
+
 class MatomoDispatcher {
   MatomoDispatcher({
     required String baseUrl,
@@ -11,6 +20,7 @@ class MatomoDispatcher {
     this.userAgent,
     this.tokenAuth,
     http.Client? httpClient,
+    this.serializer,
   })  : baseUri = Uri.parse(baseUrl),
         httpClient = httpClient ?? http.Client();
 
@@ -19,9 +29,28 @@ class MatomoDispatcher {
   final Uri baseUri;
   final String? userAgent;
   final Logger log;
+  final MatomoSerializer? serializer;
 
   static const tokenAuthUriKey = 'token_auth';
   static const userAgentHeaderKeys = 'User-Agent';
+
+  /// Serializes the given actions using the provided [serializer] or
+  /// the default serialization method.
+  ///
+  /// The default serialization method sends the actions as a JSON
+  /// payload in the format expected by Matomo.
+  dynamic serializeActions(List<Map<String, String>> actions) {
+    if (serializer != null) {
+      return serializer!(actions);
+    }
+
+    final batch = {
+      'requests': [
+        for (final action in actions) '?${buildUriForAction(action).query}',
+      ],
+    };
+    return jsonEncode(batch);
+  }
 
   /// Sends a batch of actions to the Matomo server.
   ///
@@ -42,17 +71,13 @@ class MatomoDispatcher {
       ...customHeaders,
     };
 
-    final batch = {
-      'requests': [
-        for (final action in actions) '?${buildUriForAction(action).query}',
-      ],
-    };
+    final batch = serializeActions(actions);
     log.fine(' -> $batch');
     try {
       final response = await httpClient.post(
         baseUri,
         headers: headers,
-        body: jsonEncode(batch),
+        body: batch,
       );
       final statusCode = response.statusCode;
       log.fine(' <- $statusCode');
@@ -85,6 +110,7 @@ class MatomoDispatcher {
     String? userAgent,
     Logger? log,
     http.Client? httpClient,
+    MatomoSerializer? serializer,
   }) {
     return MatomoDispatcher(
       baseUrl: baseUrl ?? baseUri.toString(),
@@ -92,6 +118,7 @@ class MatomoDispatcher {
       userAgent: userAgent ?? this.userAgent,
       log: log ?? this.log,
       httpClient: httpClient ?? this.httpClient,
+      serializer: serializer ?? this.serializer,
     );
   }
 }


### PR DESCRIPTION
### Perhaps we should support the transmission of raw formats.

For example: 

```dart

  await MatomoTracker.instance.initialize(
    // ... other params.
    customHeaders: {
      "content-type": "application/json",
    },
    serializer: (List<Map<String, String>> actions) {
      return jsonEncode({'requests': actions});
    },
  );
```