### PR TITLE
update device_info_plus to ^12.0.0, package_info_plus to ^9.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,11 +16,11 @@ environment:
 dependencies:
   clock: ^1.1.2
   collection: ^1.19.1
-  device_info_plus: ^11.3.3
+  device_info_plus: ^12.0.0
   flutter:
     sdk: flutter
   http: ^1.3.0
-  package_info_plus: ^8.3.0
+  package_info_plus: ^9.0.0
   shared_preferences: ^2.5.3
   uuid: ^4.5.1
 


### PR DESCRIPTION
Updated device_info_plus to ^12.0.0 and package_info_plus to ^9.0.0

No code changes - breaking changes:

On Android plugin now requires the following:

Android Gradle Plugin >=8.12.1
Gradle wrapper >=8.13
Kotlin 2.2.0